### PR TITLE
Adding oapi 2.x compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
     <dependencies>
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
-            <artifactId>swagger-parser-v3</artifactId>
-            <version>2.0.5</version>
+            <artifactId>swagger-parser</artifactId>
+            <version>2.0.8</version>
         </dependency>
         <dependency>
             <groupId>com.j2html</groupId>

--- a/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
+++ b/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
@@ -2,8 +2,8 @@ package com.qdesrame.openapi.diff;
 
 import com.qdesrame.openapi.diff.compare.OpenApiDiff;
 import com.qdesrame.openapi.diff.model.ChangedOpenApi;
+import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import java.io.File;
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class OpenApiCompare {
 
-  private static OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
+  private static OpenAPIParser openApiParser = new OpenAPIParser();
   private static ParseOptions options = new ParseOptions();
 
   static {
@@ -113,6 +113,6 @@ public class OpenApiCompare {
   }
 
   private static OpenAPI readLocation(String location, List<AuthorizationValue> auths) {
-    return openApiParser.read(location, auths, options);
+    return openApiParser.readLocation(location, auths, options).getOpenAPI();
   }
 }

--- a/src/main/java/com/qdesrame/openapi/diff/model/ChangedParameters.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/ChangedParameters.java
@@ -39,7 +39,13 @@ public class ChangedParameters implements ComposedChanged {
     if (increased.isEmpty() && missing.isEmpty()) {
       return DiffResult.NO_CHANGES;
     }
-    if (increased.stream().noneMatch(Parameter::getRequired) && missing.isEmpty()) {
+    if (increased
+            .stream()
+            .noneMatch(
+                p -> {
+                  return p.getRequired() != null && p.getRequired();
+                })
+        && missing.isEmpty()) {
       return DiffResult.COMPATIBLE;
     }
     return DiffResult.INCOMPATIBLE;


### PR DESCRIPTION
Resolves #53

- Upgraded parser from 2.0.5 to 2.0.8
- Switched from `OpenAPIV3Parser` to `OpenAPIParser`
- Fixed NPE around `p.getRequired()`

Unsure if this supports OpenAPI 1.2, but if there's a 1.2 converter extension available on the classpath it should work.