### PR TITLE
Refactor output parameters (allow multiple outputs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ usage: openapi-diff <old> <new>
  -l,--log <level>               use given level for log (TRACE, DEBUG,
                                 INFO, WARN, ERROR, OFF). Default: ERROR
     --markdown <file>           export diff as markdown in given file
- -o,--output <format=file>      use given format (html, markdown) for
-                                output in file
     --off                       No information printed
     --query <property=value>    use query param for authorisation
     --state                     Only output diff state: no_changes,


### PR DESCRIPTION
Remove `--output` parameter, add `--text` parameter for text output into a file, and allow all of them, `--html`, `--markdown` and `--text`, at the same time instead of only one.

The `--output` parameter is not needed because the same functionality is provided by `--html`, `--markdown`, and `--text` in a more intuitive way.