### PR TITLE
Add parameter to only fail if API changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ usage: openapi-diff <old> <new>
     --state                     Only output diff state: no_changes,
                                 incompatible, compatible
     --fail-on-incompatible      Fail only if API changes broke backward compatibility
+    --fail-on-changed           Fail if API changed but is backward compatible
     --trace                     be extra verbose
     --version                   print the version information and exit
     --warn                      Print warning information

--- a/src/main/java/com/qdesrame/openapi/diff/Main.java
+++ b/src/main/java/com/qdesrame/openapi/diff/Main.java
@@ -33,6 +33,11 @@ public class Main {
             .longOpt("fail-on-incompatible")
             .desc("Fail only if API changes broke backward compatibility")
             .build());
+    options.addOption(
+        Option.builder()
+            .longOpt("fail-on-changed")
+            .desc("Fail if API changed but is backward compatible")
+            .build());
     options.addOption(Option.builder().longOpt("trace").desc("be extra verbose").build());
     options.addOption(
         Option.builder().longOpt("debug").desc("Print debugging information").build());
@@ -186,7 +191,7 @@ public class Main {
         System.exit(0);
       } else if (line.hasOption("fail-on-incompatible")) {
         System.exit(result.isCompatible() ? 0 : 1);
-      } else {
+      } else if (line.hasOption("fail-on-changed")) {
         System.exit(result.isUnchanged() ? 0 : 1);
       }
     } catch (ParseException e) {


### PR DESCRIPTION
Instead of always failing when the API changed, this behavior is now triggered by `--fail-on-changed`.

The normal behavior is now to print the report and exit successfully.