### PR TITLE
Build openapi-diff with Java 15

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['8', '11', '14']
+        java_version: ['8', '11', '15']
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
@@ -28,6 +28,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build with Maven
-      run: ./mvnw -V -B -ff install '-DskipTests=true' '-Dmaven.javadoc.skip=true'
+      run: ./mvnw -V -B -ntp -ff install '-DskipTests=true' '-Dmaven.javadoc.skip=true'
     - name: Run tests
-      run: ./mvnw -V -B -ff verify
+      run: ./mvnw -V -B -ntp -ff verify


### PR DESCRIPTION
Build the openapi-diff project with Java 15 instead of Java 14 (both non-LTS).