### PR TITLE
[build] Master/PR/Release workflows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Run tests
-      run: ./mvnw -V -B -ntp -ff clean verify
+      run: ./mvnw -V -B -ntp -ff verify
     - name: Release Snapshot
       if: matrix.java_version == '11'
       run: ./mvnw -V -B -ntp -ff deploy

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,11 +1,12 @@
-name: Test
+name: Main Build
 on:
   push:
     branches:
-    - master
-  pull_request:
-    branches:
-    - master
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '.circleci/**'
+      - '.github/**'
 jobs:
   build:
     runs-on: 'ubuntu-latest'
@@ -18,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK
-      uses: joschi/setup-jdk@v2.3.0
+      uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java_version }}
     - uses: actions/cache@v2.1.2
@@ -27,7 +28,8 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - name: Build with Maven
-      run: ./mvnw -V -B -ntp -ff install '-DskipTests=true' '-Dmaven.javadoc.skip=true'
     - name: Run tests
-      run: ./mvnw -V -B -ntp -ff verify
+      run: ./mvnw -V -B -ntp -ff clean verify
+    - name: Release Snapshot
+      if: matrix.java_version == '11'
+      run: ./mvnw -V -B -ntp -ff deploy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,35 @@
+name: Pull Request Checks
+on:
+  - pull_request
+
+jobs:
+  cleanup:
+    name: Cleanup any previous jobs
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: ['8', '11', '15']
+    env:
+      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java_version }}
+      - uses: actions/cache@v2.1.2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Run tests
+        run: ./mvnw -V -B -ntp -ff clean verify

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,4 +32,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Run tests
-        run: ./mvnw -V -B -ntp -ff clean verify
+        run: ./mvnw -V -B -ntp -ff verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Triggered Release
+on: [workflow_dispatch]
+
+env:
+  OSS_USERNAME: ${{ secrets.OSS_USERNAME }}
+  OSS_PASSWORD: ${{ secrets.OSS_PASSWORD }}
+  GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          # Value of the distributionManagement/repository/id field of the pom.xml
+          server-id: sonatype-nexus-staging
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          server-username: OSS_USERNAME
+          server-password: OSS_PASSWORD
+          gpg-passphrase: GPG_PASSPHRASE
+      - uses: actions/cache@v2.1.2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Setup Git
+        run: |
+          git config --global committer.email "noreply@github.com"
+          git config --global committer.name "GitHub Release"
+          git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global author.name "${GITHUB_ACTOR}"
+      - name: Release
+        run: ./mvnw -B clean release:prepare release:perform -Prelease -Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}} -Drepository.url=https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
+      - name: 'if failure -> rollback'
+        if: ${{ failure() }}
+        run: |
+          ./mvnw -B release:rollback -Prelease -Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}}
+          echo "You may need to manually delete the GitHub tag, if it was created."

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Compare two OpenAPI specifications (3.x) and render the difference to HTML plaintext, or Markdown files.
 
-[![Test](https://github.com/OpenAPITools/openapi-diff/workflows/Test/badge.svg)](https://github.com/OpenAPITools/openapi-diff/actions?query=branch%3Amaster+workflow%3ATest+)
+[![Build](https://github.com/OpenAPITools/openapi-diff/workflows/Main%20Build/badge.svg)](https://github.com/OpenAPITools/openapi-diff/actions?query=branch%3Amaster+workflow%3A"Main+Build")
 
 [![Join the Slack chat room](https://img.shields.io/badge/Slack-Join%20the%20chat%20room-orange)](https://join.slack.com/t/openapi-generator/shared_invite/enQtNzAyNDMyOTU0OTE1LTY5ZDBiNDI5NzI5ZjQ1Y2E5OWVjMjZkYzY1ZGM2MWQ4YWFjMzcyNDY5MGI4NjQxNDBiMTlmZTc5NjY2ZTQ5MGM)
 


### PR DESCRIPTION
Relies on #172 before merging this.

This breaks master build from pull request builds, which will have different use cases.

Creates a release workflow which can be triggered manually from the actions tab in GitHub. This will tag/release automatically, and rollback if necessary. I haven't tested it, but it _should_ work as-is.