### PR TITLE
Add sonar coverage reporting to master build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,6 @@ on:
 env:
   OSS_USERNAME: ${{ secrets.OSS_USERNAME }}
   OSS_PASSWORD: ${{ secrets.OSS_PASSWORD }}
-  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,7 @@ on:
 env:
   OSS_USERNAME: ${{ secrets.OSS_USERNAME }}
   OSS_PASSWORD: ${{ secrets.OSS_PASSWORD }}
+  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 jobs:
   build:
@@ -40,7 +41,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Run tests
-      run: ./mvnw -V -B -ntp -ff verify
+      run: ./mvnw -V -B -ntp -ff verify jacoco:report
+    - name: Static Analysis (Sonar)
+      # Sonar will require at least Java 11 soon.
+      if: matrix.java_version == '11'
+      run: ./mvnw -B -ntp -ff jacoco:report-aggregate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenAPITools_openapi-diff -Dsonar.organization=openapitools -Dsonar.host.url=https://sonarcloud.io -Dsonar.branch.name=${GITHUB_REF##*/}
     - name: Release Snapshot
       if: matrix.java_version == '11'
       run: ./mvnw -V -B -ntp -ff deploy

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -40,12 +40,21 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v2.1.2
+      if: matrix.java_version == '11'
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
     - name: Run tests
       run: ./mvnw -V -B -ntp -ff verify jacoco:report
     - name: Static Analysis (Sonar)
-      # Sonar will require at least Java 11 soon.
       if: matrix.java_version == '11'
-      run: ./mvnw -B -ntp -ff jacoco:report-aggregate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenAPITools_openapi-diff -Dsonar.organization=openapitools -Dsonar.host.url=https://sonarcloud.io -Dsonar.branch.name=${GITHUB_REF##*/}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: ./mvnw -B -ntp -ff org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
     - name: Release Snapshot
       if: matrix.java_version == '11'
       run: ./mvnw -V -B -ntp -ff deploy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,5 +32,18 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v2.1.2
+        if: matrix.java_version == '11'
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
       - name: Run tests
         run: ./mvnw -V -B -ntp -ff verify
+      - name: Static Analysis (Sonar)
+        if: matrix.java_version == '11'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./mvnw -B -ntp -ff org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Compare two OpenAPI specifications (3.x) and render the difference to HTML plaintext, or Markdown files.
 
 [![Build](https://github.com/OpenAPITools/openapi-diff/workflows/Main%20Build/badge.svg)](https://github.com/OpenAPITools/openapi-diff/actions?query=branch%3Amaster+workflow%3A"Main+Build")
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=OpenAPITools_openapi-diff&metric=alert_status)](https://sonarcloud.io/dashboard?id=OpenAPITools_openapi-diff)
 [![Maven Central](https://img.shields.io/maven-central/v/org.openapitools.openapidiff/openapi-diff-core)](https://search.maven.org/artifact/org.openapitools.openapidiff/openapi-diff-core)
 [![Join the Slack chat room](https://img.shields.io/badge/Slack-Join%20the%20chat%20room-orange)](https://join.slack.com/t/openapi-generator/shared_invite/enQtNzAyNDMyOTU0OTE1LTY5ZDBiNDI5NzI5ZjQ1Y2E5OWVjMjZkYzY1ZGM2MWQ4YWFjMzcyNDY5MGI4NjQxNDBiMTlmZTc5NjY2ZTQ5MGM)
 

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,11 @@
                     <version>1.6.8</version>
                     <extensions>true</extensions>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.6</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -346,6 +351,51 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-site</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <!-- Example: -->
+                        <!-- <exclude>**/gradle-wrapper.jar</exclude> -->
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.scm.id>github</project.scm.id>
+
+        <sonar.organization>openapitools</sonar.organization>
+        <sonar.projectKey>OpenAPITools_openapi-diff</sonar.projectKey>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
+
         <swagger-parser.version>2.0.22</swagger-parser.version>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
@@ -311,6 +317,11 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.6</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>3.7.0.1746</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -362,40 +373,7 @@
                             <goal>prepare-agent</goal>
                         </goals>
                     </execution>
-                    <execution>
-                        <id>jacoco-site</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <rule>
-                                    <element>PACKAGE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
                 </executions>
-                <configuration>
-                    <excludes>
-                        <!-- Example: -->
-                        <!-- <exclude>**/gradle-wrapper.jar</exclude> -->
-                    </excludes>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Submits analysis to sonar on master branch build.

New sonar project is at https://sonarcloud.io/dashboard?id=OpenAPITools_openapi-diff

This submits sonar for the Java 11 build. Sonar will complain for any code submitted and built against Java 8, as support for Java 8 will be removed soon. This also adds and configures Jacoco for coverage instrumentation in the root pom. The `sonar.branch.name` configuration is dynamic as this would allow extending this workflow for other branches without submitting these all to `master`.

As a side note, there's no clean way to run a sonar PR check because Sonar requires a secret token and these are not available in the `pull_request` event. We _might_ be able to work something out with the `pull_request_target` event (which runs in the scope of the master branch), but that would require a bit of work and poses a potential security risk. Sonar also doesn't support automated checks for compiled languages.


I haven't included a sonar badge in the readme here. Some options are below.

## "official" badge

```markdown
[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=OpenAPITools_openapi-diff&metric=alert_status)](https://sonarcloud.io/dashboard?id=OpenAPITools_openapi-diff)
```

Renders as:

[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=OpenAPITools_openapi-diff&metric=alert_status)](https://sonarcloud.io/dashboard?id=OpenAPITools_openapi-diff)

## Coverage Shield

```markdown
![Sonar Coverage](https://img.shields.io/sonar/coverage/OpenAPITools_openapi-diff?color=blue&label=Code%20Coverage&server=https%3A%2F%2Fsonarcloud.io&style=flat-square)
```

Renders as:

![Sonar Coverage](https://img.shields.io/sonar/coverage/OpenAPITools_openapi-diff?color=blue&label=Code%20Coverage&server=https%3A%2F%2Fsonarcloud.io&style=flat-square)

## Quality Gate Shield

```markdown
![Sonar Quality Gate](https://img.shields.io/sonar/quality_gate/OpenAPITools_openapi-diff?label=Quality%20Gate&server=https%3A%2F%2Fsonarcloud.io&style=flat-square)
```

Renders as:

![Sonar Quality Gate](https://img.shields.io/sonar/quality_gate/OpenAPITools_openapi-diff?label=Quality%20Gate&server=https%3A%2F%2Fsonarcloud.io&style=flat-square)

## Total Tests Shield

```markdown
![Sonar Test Count](https://img.shields.io/sonar/total_tests/OpenAPITools_openapi-diff?label=Total%20Tests&server=https%3A%2F%2Fsonarcloud.io&style=flat-square)
```

Renders as:

![Sonar Test Count](https://img.shields.io/sonar/total_tests/OpenAPITools_openapi-diff?label=Total%20Tests&server=https%3A%2F%2Fsonarcloud.io&style=flat-square)
