### PR TITLE
Add tests for content-type changes in request/response

### DIFF
--- a/core/src/test/java/org/openapitools/openapidiff/core/ContentDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/ContentDiffTest.java
@@ -27,4 +27,36 @@ public class ContentDiffTest {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_DOC2, OPENAPI_DOC2);
     assertThat(changedOpenApi.isUnchanged()).isTrue();
   }
+
+  @Test
+  public void testAddedResponseContentTypeDiff() {
+    ChangedOpenApi changedOpenApi =
+        OpenApiCompare.fromLocations(
+            "content_type_response_add_1.yaml", "content_type_response_add_2.yaml");
+    assertThat(changedOpenApi.isCompatible()).isFalse();
+  }
+
+  @Test
+  public void testRemovedResponseContentTypeDiff() {
+    ChangedOpenApi changedOpenApi =
+        OpenApiCompare.fromLocations(
+            "content_type_response_add_2.yaml", "content_type_response_add_1.yaml");
+    assertThat(changedOpenApi.isCompatible()).isTrue();
+  }
+
+  @Test
+  public void testAddedRequestContentTypeDiff() {
+    ChangedOpenApi changedOpenApi =
+        OpenApiCompare.fromLocations(
+            "content_type_request_add_1.yaml", "content_type_request_add_2.yaml");
+    assertThat(changedOpenApi.isCompatible()).isTrue();
+  }
+
+  @Test
+  public void testRemovedRequestContentTypeDiff() {
+    ChangedOpenApi changedOpenApi =
+        OpenApiCompare.fromLocations(
+            "content_type_request_add_2.yaml", "content_type_request_add_1.yaml");
+    assertThat(changedOpenApi.isCompatible()).isFalse();
+  }
 }

--- a/core/src/test/resources/content_type_request_add_1.yaml
+++ b/core/src/test/resources/content_type_request_add_1.yaml
@@ -1,0 +1,31 @@
+---
+openapi: "3.0.1"
+info:
+  title: "Test title"
+  description: "This is a test metadata"
+  termsOfService: "http://test.com"
+  contact:
+    name: "Mark Snijder"
+    url: "marksnijder.nl"
+    email: "snijderd@gmail.com"
+  license:
+    name: "To be decided"
+    url: "http://test.com"
+  version: "version 1.0"
+paths:
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: response
+          content:
+            application/json:
+              schema:
+                type: string

--- a/core/src/test/resources/content_type_request_add_2.yaml
+++ b/core/src/test/resources/content_type_request_add_2.yaml
@@ -1,0 +1,34 @@
+---
+openapi: "3.0.1"
+info:
+  title: "Test title"
+  description: "This is a test metadata"
+  termsOfService: "http://test.com"
+  contact:
+    name: "Mark Snijder"
+    url: "marksnijder.nl"
+    email: "snijderd@gmail.com"
+  license:
+    name: "To be decided"
+    url: "http://test.com"
+  version: "version 1.0"
+paths:
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          application/xml:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: response
+          content:
+            application/json:
+              schema:
+                type: string

--- a/core/src/test/resources/content_type_response_add_1.yaml
+++ b/core/src/test/resources/content_type_response_add_1.yaml
@@ -1,0 +1,26 @@
+---
+openapi: "3.0.1"
+info:
+  title: "Test title"
+  description: "This is a test metadata"
+  termsOfService: "http://test.com"
+  contact:
+    name: "Mark Snijder"
+    url: "marksnijder.nl"
+    email: "snijderd@gmail.com"
+  license:
+    name: "To be decided"
+    url: "http://test.com"
+  version: "version 1.0"
+paths:
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      responses:
+        '200':
+          description: response
+          content:
+            application/json:
+              schema:
+                type: string

--- a/core/src/test/resources/content_type_response_add_2.yaml
+++ b/core/src/test/resources/content_type_response_add_2.yaml
@@ -1,0 +1,29 @@
+---
+openapi: "3.0.1"
+info:
+  title: "Test title"
+  description: "This is a test metadata"
+  termsOfService: "http://test.com"
+  contact:
+    name: "Mark Snijder"
+    url: "marksnijder.nl"
+    email: "snijderd@gmail.com"
+  license:
+    name: "To be decided"
+    url: "http://test.com"
+  version: "version 1.0"
+paths:
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      responses:
+        '200':
+          description: response
+          content:
+            application/json:
+              schema:
+                type: string
+            application/xml:
+              schema:
+                type: string


### PR DESCRIPTION
This PR adds some test cases that I wrote while determining the backwards compatibility guarantees. You might want them in the test suite for future stability.