### PR TITLE
Add diff results of operation ID (metadata)

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/OperationDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/OperationDiff.java
@@ -32,6 +32,10 @@ public class OperationDiff {
         .getMetadataDiff()
         .diff(oldOperation.getDescription(), newOperation.getDescription(), context)
         .ifPresent(changedOperation::setDescription);
+    openApiDiff
+        .getMetadataDiff()
+        .diff(oldOperation.getOperationId(), newOperation.getOperationId(), context)
+        .ifPresent(changedOperation::setOperationId);
     changedOperation.setDeprecated(
         !Boolean.TRUE.equals(oldOperation.getDeprecated())
             && Boolean.TRUE.equals(newOperation.getDeprecated()));

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOperation.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOperation.java
@@ -234,7 +234,7 @@ public class ChangedOperation implements ComposedChanged {
         + this.getSummary()
         + ", description="
         + this.getDescription()
-        + ", description="
+        + ", operationId="
         + this.getOperationId()
         + ", deprecated="
         + this.isDeprecated()

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOperation.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOperation.java
@@ -15,6 +15,7 @@ public class ChangedOperation implements ComposedChanged {
   private PathItem.HttpMethod httpMethod;
   private ChangedMetadata summary;
   private ChangedMetadata description;
+  private ChangedMetadata operationId;
   private boolean deprecated;
   private ChangedParameters parameters;
   private ChangedRequestBody requestBody;
@@ -38,6 +39,7 @@ public class ChangedOperation implements ComposedChanged {
     return Arrays.asList(
         summary,
         description,
+        operationId,
         parameters,
         requestBody,
         apiResponses,
@@ -84,6 +86,10 @@ public class ChangedOperation implements ComposedChanged {
 
   public ChangedMetadata getDescription() {
     return this.description;
+  }
+
+  public ChangedMetadata getOperationId() {
+    return this.operationId;
   }
 
   public boolean isDeprecated() {
@@ -140,6 +146,11 @@ public class ChangedOperation implements ComposedChanged {
     return this;
   }
 
+  public ChangedOperation setOperationId(final ChangedMetadata operationId) {
+    this.operationId = operationId;
+    return this;
+  }
+
   public ChangedOperation setDeprecated(final boolean deprecated) {
     this.deprecated = deprecated;
     return this;
@@ -183,6 +194,7 @@ public class ChangedOperation implements ComposedChanged {
         && httpMethod == that.httpMethod
         && Objects.equals(summary, that.summary)
         && Objects.equals(description, that.description)
+        && Objects.equals(operationId, that.operationId)
         && Objects.equals(parameters, that.parameters)
         && Objects.equals(requestBody, that.requestBody)
         && Objects.equals(apiResponses, that.apiResponses)
@@ -199,6 +211,7 @@ public class ChangedOperation implements ComposedChanged {
         httpMethod,
         summary,
         description,
+        operationId,
         deprecated,
         parameters,
         requestBody,
@@ -221,6 +234,8 @@ public class ChangedOperation implements ComposedChanged {
         + this.getSummary()
         + ", description="
         + this.getDescription()
+        + ", description="
+        + this.getOperationId()
         + ", deprecated="
         + this.isDeprecated()
         + ", parameters="

--- a/core/src/test/java/org/openapitools/openapidiff/core/OperationDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/OperationDiffTest.java
@@ -1,0 +1,23 @@
+package org.openapitools.openapidiff.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+import org.openapitools.openapidiff.core.model.DiffResult;
+
+public class OperationDiffTest {
+
+  private final String OPENAPI_DOC1 = "operation_diff_1.yaml";
+  private final String OPENAPI_DOC2 = "operation_diff_2.yaml";
+
+  @Test
+  public void testContentDiffWithOneEmptyMediaType() {
+    ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_DOC2);
+    assertThat(changedOpenApi.isChanged()).isEqualTo(DiffResult.METADATA);
+    assertThat(changedOpenApi.isDifferent()).isTrue();
+    assertThat(changedOpenApi.getChangedOperations().size()).isEqualTo(1);
+    assertThat(changedOpenApi.getChangedOperations().get(0).getOperationId().isDifferent())
+        .isTrue();
+  }
+}

--- a/core/src/test/resources/operation_diff_1.yaml
+++ b/core/src/test/resources/operation_diff_1.yaml
@@ -1,0 +1,24 @@
+---
+openapi: "3.0.1"
+info:
+  title: "Test title"
+  description: "This is a test metadata"
+  termsOfService: "http://test.com"
+  contact:
+    name: "Mark Snijder"
+    url: "marksnijder.nl"
+    email: "snijderd@gmail.com"
+  license:
+    name: "To be decided"
+    url: "http://test.com"
+  version: "version 1.0"
+paths:
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: operation
+      responses:
+        '200':
+          description: response
+          content:
+            application/json: {}

--- a/core/src/test/resources/operation_diff_2.yaml
+++ b/core/src/test/resources/operation_diff_2.yaml
@@ -1,0 +1,24 @@
+---
+openapi: "3.0.1"
+info:
+  title: "Test title"
+  description: "This is a test metadata"
+  termsOfService: "http://test.com"
+  contact:
+    name: "Mark Snijder"
+    url: "marksnijder.nl"
+    email: "snijderd@gmail.com"
+  license:
+    name: "To be decided"
+    url: "http://test.com"
+  version: "version 1.0"
+paths:
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: changed
+      responses:
+        '200':
+          description: response
+          content:
+            application/json: {}


### PR DESCRIPTION
@joschi

Closes #189 

This pull request adds a diff analysis of operation ID. It is classified as a backwards compatible metdata change. Tests also included.

Besides of this PR: what a great library. Thanks a lot for creating and maintaining this. Even creating the PR was a joy thanks to the nice code layout :)