### PR TITLE
Run SonarCloud analysis only when SONAR_TOKEN is available

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -40,6 +40,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Cache SonarCloud packages
+      if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       uses: actions/cache@v2.1.3
       if: matrix.java_version == '11'
       with:
@@ -49,7 +52,7 @@ jobs:
     - name: Run tests
       run: ./mvnw -V -B -ntp -ff verify jacoco:report
     - name: Static Analysis (Sonar)
-      if: matrix.java_version == '11'
+      if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,9 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Cache SonarCloud packages
         uses: actions/cache@v2.1.3
-        if: matrix.java_version == '11'
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -42,7 +44,7 @@ jobs:
       - name: Run tests
         run: ./mvnw -V -B -ntp -ff verify
       - name: Static Analysis (Sonar)
-        if: matrix.java_version == '11'
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Forked repositories don't have access to the `SONAR_TOKEN` secret and thus cannot run the SonarCloud analysis as part of the build.

Refs #184