### PR TITLE
Fix nullable API response in diff

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/ApiResponseDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/ApiResponseDiff.java
@@ -12,6 +12,8 @@ import org.openapitools.openapidiff.core.model.ChangedApiResponse;
 import org.openapitools.openapidiff.core.model.ChangedResponse;
 import org.openapitools.openapidiff.core.model.DiffContext;
 
+import javax.annotation.Nullable;
+
 /** Created by adarsh.sharma on 04/01/18. */
 public class ApiResponseDiff {
   private final OpenApiDiff openApiDiff;
@@ -20,15 +22,14 @@ public class ApiResponseDiff {
     this.openApiDiff = openApiDiff;
   }
 
-  public Optional<ChangedApiResponse> diff(
-      ApiResponses left, ApiResponses right, DiffContext context) {
+  public Optional<ChangedApiResponse> diff(@Nullable  ApiResponses left, @Nullable ApiResponses right, DiffContext context) {
     MapKeyDiff<String, ApiResponse> responseMapKeyDiff = MapKeyDiff.diff(left, right);
     List<String> sharedResponseCodes = responseMapKeyDiff.getSharedKey();
     Map<String, ChangedResponse> resps = new LinkedHashMap<>();
     for (String responseCode : sharedResponseCodes) {
       openApiDiff
           .getResponseDiff()
-          .diff(left.get(responseCode), right.get(responseCode), context)
+          .diff(left != null ? left.get(responseCode) : null, right != null ? right.get(responseCode) : null, context)
           .ifPresent(changedResponse -> resps.put(responseCode, changedResponse));
     }
     ChangedApiResponse changedApiResponse =
@@ -38,7 +39,7 @@ public class ApiResponseDiff {
             .setChanged(resps);
     openApiDiff
         .getExtensionsDiff()
-        .diff(left.getExtensions(), right.getExtensions(), context)
+        .diff(left != null ? left.getExtensions() : null, right != null ? right.getExtensions() : null, context)
         .ifPresent(changedApiResponse::setExtensions);
     return isChanged(changedApiResponse);
   }

--- a/core/src/test/java/org/openapitools/openapidiff/core/compare/ApiResponseDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/compare/ApiResponseDiffTest.java
@@ -1,0 +1,27 @@
+package org.openapitools.openapidiff.core.compare;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiBackwardCompatible;
+import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiBackwardIncompatible;
+
+
+class ApiResponseDiffTest extends Assertions {
+    /***
+     * This is a regression test - when no responses were set, we would get an exception
+     * since the OpenAPI object has a `null` ApiResponses field.
+     */
+    @Test
+    public void testNoResponseInPrevious() {
+        // The previous API had no response, so adding a response shape is still compatible.
+        assertOpenApiBackwardCompatible(
+                "backwardCompatibility/apiResponse_diff_1.yaml",
+                "backwardCompatibility/apiResponse_diff_2.yaml", true);
+
+        // Removing the response shape is backwards incompatible.
+        assertOpenApiBackwardIncompatible(
+                "backwardCompatibility/apiResponse_diff_2.yaml",
+                "backwardCompatibility/apiResponse_diff_1.yaml");
+    }
+}

--- a/core/src/test/resources/backwardCompatibility/apiResponse_diff_1.yaml
+++ b/core/src/test/resources/backwardCompatibility/apiResponse_diff_1.yaml
@@ -1,0 +1,7 @@
+openapi: 3.0.0
+info:
+  title: Swagger Petstore
+paths:
+  /store/inventory:
+    get:
+      operationId: asdf

--- a/core/src/test/resources/backwardCompatibility/apiResponse_diff_2.yaml
+++ b/core/src/test/resources/backwardCompatibility/apiResponse_diff_2.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: Swagger Petstore
+paths:
+  /store/inventory:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  title:
+                    type: string


### PR DESCRIPTION
@joschi thanks for the prompt fix on my previous issue! Thought I'd cut a PR for something I ran into recently.

Running backwards compatibility checks fail when either a response body is removed or there wasn't a response body to start with.

Fixed with a few null checks.