### PR TITLE
Handle missing security schemes component

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
@@ -1,20 +1,19 @@
 package org.openapitools.openapidiff.core.compare;
 
-import static org.openapitools.openapidiff.core.utils.ChangedUtils.isChanged;
-
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.openapitools.openapidiff.core.model.ChangedSecurityRequirement;
 import org.openapitools.openapidiff.core.model.ChangedSecurityRequirements;
 import org.openapitools.openapidiff.core.model.DiffContext;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.openapitools.openapidiff.core.utils.ChangedUtils.isChanged;
 
 /** Created by adarsh.sharma on 07/01/18. */
 public class SecurityRequirementsDiff {
@@ -55,10 +54,16 @@ public class SecurityRequirementsDiff {
     return securityRequirement.keySet().stream()
         .map(
             x -> {
-              SecurityScheme result = components.getSecuritySchemes().get(x);
+              Map<String, SecurityScheme> securitySchemes = components.getSecuritySchemes();
+              if (securitySchemes == null) {
+                throw new IllegalArgumentException("Missing securitySchemes component definition.");
+              }
+
+              SecurityScheme result = securitySchemes.get(x);
               if (result == null) {
                 throw new IllegalArgumentException("Impossible to find security scheme: " + x);
               }
+
               return result;
             })
         .map(this::getPair)

--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
@@ -1,22 +1,21 @@
 package org.openapitools.openapidiff.core.compare;
 
+import static org.openapitools.openapidiff.core.utils.ChangedUtils.isChanged;
+
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.openapitools.openapidiff.core.model.ChangedSecurityRequirement;
 import org.openapitools.openapidiff.core.model.ChangedSecurityRequirements;
 import org.openapitools.openapidiff.core.model.DiffContext;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static org.openapitools.openapidiff.core.utils.ChangedUtils.isChanged;
 
 /** Created by adarsh.sharma on 07/01/18. */
 public class SecurityRequirementsDiff {

--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
@@ -10,7 +10,10 @@ import org.openapitools.openapidiff.core.model.ChangedSecurityRequirement;
 import org.openapitools.openapidiff.core.model.ChangedSecurityRequirements;
 import org.openapitools.openapidiff.core.model.DiffContext;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.openapitools.openapidiff.core.utils.ChangedUtils.isChanged;

--- a/core/src/test/java/org/openapitools/openapidiff/core/SecurityDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/SecurityDiffTest.java
@@ -12,6 +12,7 @@ public class SecurityDiffTest {
   private final String OPENAPI_DOC1 = "security_diff_1.yaml";
   private final String OPENAPI_DOC2 = "security_diff_2.yaml";
   private final String OPENAPI_DOC3 = "security_diff_3.yaml";
+  private final String OPENAPI_DOC4 = "security_diff_4.yaml";
 
   @Test
   public void testDiffDifferent() {
@@ -89,5 +90,8 @@ public class SecurityDiffTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> OpenApiCompare.fromLocations(OPENAPI_DOC3, OPENAPI_DOC3));
+    assertThrows(
+            IllegalArgumentException.class,
+            () -> OpenApiCompare.fromLocations(OPENAPI_DOC4, OPENAPI_DOC4));
   }
 }

--- a/core/src/test/resources/security_diff_4.yaml
+++ b/core/src/test/resources/security_diff_4.yaml
@@ -1,0 +1,224 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: 'http://swagger.io'
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: 'http://swagger.io'
+security:
+  - petstore_auth:
+      - 'write:pets'
+      - 'read:pets'
+  - unknown: []
+paths:
+  '/pet/{petId}':
+    parameters:
+      - name: newHeaderParam
+        in: header
+        required: false
+        schema:
+          type: integer
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: newHeaderParam
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+      - petstore_auth:
+        - 'write:pets'
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '405':
+          description: Invalid input
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+  /pet2:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '405':
+          description: Invalid input
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+  /pet3:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '405':
+          description: Invalid input
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+      security:
+      - petstore_auth:
+        - 'write:pets'
+        - 'read:pets'
+  /pet/findByStatus2:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          deprecated: true
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      security:
+      - tenant: []
+        user: []
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+components:
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true
+  schemas:
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          type: string
+        name:
+          type: string
+          example: doggie
+        newField:
+          type: string
+          example: a field demo
+          description: a field demo
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet


### PR DESCRIPTION
I was running into a `NullPointerException` that I did not expect when diffing two specifications.

Turned out my specification was missing `components.securitySchemes` because it was using a custom extension, but the error was not really expected or informative.

This pull request:
* patches the code to throw an explicit `IllegalArgumentException` if `components.securitySchemes` is missing,
* adds a test resource `security_diff_4.yaml` which is copied from `security_diff_3.yaml` but removes `components.securitySchemes`,
* adds an assertion that diffing this file will throw `IllegalArgumentException` (instead of `NullPointerException`) -- this test fails without the patch.

Note: this PR _continues_ to assume that missing `components.securitySchemes` is problematic (i.e., I will need to update my specification file that started this).

cc @joschi 