### PR TITLE
Make large, recursive schemas diff-able by deferring computation of diffs 

### DIFF
--- a/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
+++ b/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
@@ -1,14 +1,11 @@
 package org.openapitools.openapidiff.cli;
 
+import io.swagger.v3.parser.core.models.AuthorizationValue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import io.swagger.v3.parser.core.models.AuthorizationValue;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;

--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/ApiResponseDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/ApiResponseDiff.java
@@ -1,18 +1,17 @@
 package org.openapitools.openapidiff.core.compare;
 
-import static org.openapitools.openapidiff.core.utils.ChangedUtils.isChanged;
-
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import javax.annotation.Nullable;
+import org.openapitools.openapidiff.core.model.Changed;
 import org.openapitools.openapidiff.core.model.ChangedApiResponse;
 import org.openapitools.openapidiff.core.model.ChangedResponse;
 import org.openapitools.openapidiff.core.model.DiffContext;
-
-import javax.annotation.Nullable;
+import org.openapitools.openapidiff.core.model.deferred.DeferredBuilder;
+import org.openapitools.openapidiff.core.model.deferred.DeferredChanged;
 
 /** Created by adarsh.sharma on 04/01/18. */
 public class ApiResponseDiff {
@@ -22,14 +21,22 @@ public class ApiResponseDiff {
     this.openApiDiff = openApiDiff;
   }
 
-  public Optional<ChangedApiResponse> diff(@Nullable  ApiResponses left, @Nullable ApiResponses right, DiffContext context) {
+  public DeferredChanged<ChangedApiResponse> diff(
+      @Nullable ApiResponses left, @Nullable ApiResponses right, DiffContext context) {
     MapKeyDiff<String, ApiResponse> responseMapKeyDiff = MapKeyDiff.diff(left, right);
     List<String> sharedResponseCodes = responseMapKeyDiff.getSharedKey();
     Map<String, ChangedResponse> resps = new LinkedHashMap<>();
+    DeferredBuilder<Changed> builder = new DeferredBuilder<>();
+
     for (String responseCode : sharedResponseCodes) {
-      openApiDiff
-          .getResponseDiff()
-          .diff(left != null ? left.get(responseCode) : null, right != null ? right.get(responseCode) : null, context)
+      builder
+          .with(
+              openApiDiff
+                  .getResponseDiff()
+                  .diff(
+                      left != null ? left.get(responseCode) : null,
+                      right != null ? right.get(responseCode) : null,
+                      context))
           .ifPresent(changedResponse -> resps.put(responseCode, changedResponse));
     }
     ChangedApiResponse changedApiResponse =
@@ -37,10 +44,15 @@ public class ApiResponseDiff {
             .setIncreased(responseMapKeyDiff.getIncreased())
             .setMissing(responseMapKeyDiff.getMissing())
             .setChanged(resps);
-    openApiDiff
-        .getExtensionsDiff()
-        .diff(left != null ? left.getExtensions() : null, right != null ? right.getExtensions() : null, context)
+    builder
+        .with(
+            openApiDiff
+                .getExtensionsDiff()
+                .diff(
+                    left != null ? left.getExtensions() : null,
+                    right != null ? right.getExtensions() : null,
+                    context))
         .ifPresent(changedApiResponse::setExtensions);
-    return isChanged(changedApiResponse);
+    return builder.buildIsChanged(changedApiResponse);
   }
 }

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/Change.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/Change.java
@@ -22,7 +22,7 @@ public final class Change<T> {
   public enum Type {
     ADDED,
     CHANGED,
-    REMOVED;
+    REMOVED
   }
 
   public Change(final T oldValue, final T newValue, final Type type) {

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOpenApi.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOpenApi.java
@@ -13,6 +13,7 @@ public class ChangedOpenApi implements ComposedChanged {
   private List<Endpoint> newEndpoints;
   private List<Endpoint> missingEndpoints;
   private List<ChangedOperation> changedOperations;
+  private List<ChangedSchema> changedSchemas;
   private ChangedExtensions changedExtensions;
 
   public List<Endpoint> getDeprecatedEndpoints() {
@@ -27,7 +28,9 @@ public class ChangedOpenApi implements ComposedChanged {
 
   @Override
   public List<Changed> getChangedElements() {
-    return Stream.concat(changedOperations.stream(), Stream.of(changedExtensions))
+    return Stream.concat(
+            Stream.concat(changedOperations.stream(), Stream.of(changedExtensions)),
+            changedSchemas.stream())
         .collect(Collectors.toList());
   }
 
@@ -68,6 +71,10 @@ public class ChangedOpenApi implements ComposedChanged {
     return this.changedExtensions;
   }
 
+  public List<ChangedSchema> getChangedSchemas() {
+    return changedSchemas;
+  }
+
   public ChangedOpenApi setOldSpecOpenApi(final OpenAPI oldSpecOpenApi) {
     this.oldSpecOpenApi = oldSpecOpenApi;
     return this;
@@ -95,6 +102,11 @@ public class ChangedOpenApi implements ComposedChanged {
 
   public ChangedOpenApi setChangedExtensions(final ChangedExtensions changedExtensions) {
     this.changedExtensions = changedExtensions;
+    return this;
+  }
+
+  public ChangedOpenApi setChangedSchemas(final List<ChangedSchema> changedSchemas) {
+    this.changedSchemas = changedSchemas;
     return this;
   }
 

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/DeferredBuilder.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/DeferredBuilder.java
@@ -1,0 +1,106 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import static org.openapitools.openapidiff.core.utils.ChangedUtils.isChanged;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.openapitools.openapidiff.core.model.Changed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeferredBuilder<T> implements Consumer<DeferredChanged<T>> {
+  private static final Logger log = LoggerFactory.getLogger(DeferredBuilder.class);
+
+  private final List<DeferredChanged<? extends T>> deferredValues = new ArrayList<>();
+  private final List<Consumer<Optional<List<Optional<? super T>>>>> whenSet = new ArrayList<>();
+
+  public <V extends T> Optional<V> with(Optional<V> value) {
+    return value;
+  }
+
+  public <V extends T> DeferredChanged<V> with(DeferredChanged<V> value) {
+    deferredValues.add(value);
+    return value;
+  }
+
+  public <V extends T> DeferredBuilder<T> add(DeferredChanged<V> value) {
+    deferredValues.add(value);
+    return this;
+  }
+
+  public <V extends T> DeferredBuilder<T> addAll(List<DeferredChanged<V>> values) {
+    deferredValues.addAll(values);
+    return this;
+  }
+
+  public <V extends T> DeferredBuilder<T> addAll(Stream<DeferredChanged<V>> values) {
+    deferredValues.addAll(values.collect(Collectors.toList()));
+    return this;
+  }
+
+  public DeferredBuilder<T> whenSet(Consumer<Optional<List<Optional<? super T>>>> consumer) {
+    whenSet.add(consumer);
+    return this;
+  }
+
+  @Override
+  public void accept(DeferredChanged<T> value) {
+    deferredValues.add(value);
+  }
+
+  public DeferredChanged<List<Optional<? super T>>> build() {
+    if (deferredValues.isEmpty()) {
+      return DeferredChanged.empty();
+    }
+
+    log.debug("Building collected deferred {}", DeferredLogger.logValue(deferredValues));
+
+    final PendingChanged<List<Optional<? super T>>> changed = new PendingChanged();
+    whenSet.forEach(changed::whenSet);
+
+    Optional[] values = new Optional[deferredValues.size()];
+
+    IntStream.range(0, deferredValues.size())
+        .forEach(
+            (i) -> {
+              DeferredChanged<? extends T> deferredItem = deferredValues.get(i);
+              deferredItem.whenSet(
+                  (value) -> {
+                    values[i] = value;
+                    log.debug(
+                        "Collected deferred item set this={}, item={}, values = {}",
+                        this,
+                        DeferredLogger.logValue(value),
+                        DeferredLogger.logValue(values));
+                    if (isFull(values)) {
+                      log.debug(
+                          "Collected deferred triggering complete this={}, values = {}",
+                          this,
+                          DeferredLogger.logValue(values));
+                      changed.setValue(Optional.of(Arrays.asList(values)));
+                    }
+                  });
+            });
+
+    return changed;
+  }
+
+  public <V extends Changed> DeferredChanged<V> buildIsChanged(V changed) {
+    return build().flatMap((values) -> (DeferredChanged<V>) DeferredChanged.of(isChanged(changed)));
+  }
+
+  private static boolean isFull(Object[] values) {
+    for (int i = 0; i < values.length; i++) {
+      if (values[i] == null) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/DeferredChanged.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/DeferredChanged.java
@@ -1,0 +1,38 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.openapitools.openapidiff.core.model.ChangedResponse;
+
+public interface DeferredChanged<T> {
+
+  void ifPresent(Consumer<T> consumer);
+
+  void whenSet(Consumer<Optional<T>> consumer);
+
+  <Q> DeferredChanged<Q> map(Function<Optional<T>, Q> consumer);
+
+  <Q> DeferredChanged<Q> mapOptional(Function<Optional<T>, Optional<Q>> consumer);
+
+  <Q> DeferredChanged<Q> flatMap(Function<Optional<T>, DeferredChanged<Q>> consumer);
+
+  static <T> DeferredChanged<T> empty() {
+    return RealizedChanged.empty();
+  }
+
+  static <T> DeferredChanged<T> ofNullable(@Nullable T value) {
+    return new RealizedChanged(value);
+  }
+
+  static <T> DeferredChanged<ChangedResponse> of(Optional<T> changed) {
+    return new RealizedChanged(changed);
+  }
+
+  boolean isPresent();
+
+  boolean isValueSet();
+
+  T get();
+}

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/DeferredLogger.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/DeferredLogger.java
@@ -1,0 +1,71 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.openapitools.openapidiff.core.model.Changed;
+import org.openapitools.openapidiff.core.model.ComposedChanged;
+
+public class DeferredLogger {
+
+  public static <T> Object logValue(Object value) {
+    return new Object() {
+      public String toString() {
+        return valueToString(value);
+      }
+    };
+  }
+
+  public static String optionalToString(Optional<?> value) {
+    if (value == null) {
+      return "null";
+    } else {
+      return value.map((v) -> "Optional[" + valueToString(v) + "]").orElse("Optional[empty]");
+    }
+  }
+
+  public static String changedToString(Changed value) {
+    if (value instanceof ComposedChanged) {
+      return "Changed: " + value.getClass() + " (composed) ";
+    } else {
+      return "Changed: " + value.getClass() + " " + value.isChanged();
+    }
+  }
+
+  public static String streamToString(Stream<?> values) {
+    return "[" + values.map(v -> valueToString(v)).collect(Collectors.joining(", ")) + "]";
+  }
+
+  public static String deferredChangeToString(DeferredChanged<?> deferredChanged) {
+    if (deferredChanged.isValueSet()) {
+      if (deferredChanged.isPresent()) {
+        Object value = deferredChanged.get();
+        return valueToString(value);
+      } else {
+        return deferredChanged.toString();
+      }
+    } else {
+      return deferredChanged.toString();
+    }
+  }
+
+  public static String valueToString(Object value) {
+    if (value == null) {
+      return "null";
+    } else if (value instanceof Changed) {
+      return changedToString((Changed) value);
+    } else if (value instanceof Optional) {
+      return optionalToString((Optional) value);
+    } else if (value instanceof DeferredChanged) {
+      return deferredChangeToString((DeferredChanged) value);
+    } else if (value.getClass().isArray()) {
+      return streamToString(Arrays.stream((Object[]) value));
+    } else if (value instanceof Collection) {
+      return streamToString(((Collection) value).stream());
+    } else {
+      return value.toString();
+    }
+  }
+}

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/DeferredSchemaCache.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/DeferredSchemaCache.java
@@ -1,0 +1,122 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.openapitools.openapidiff.core.compare.CacheKey;
+import org.openapitools.openapidiff.core.compare.OpenApiDiff;
+import org.openapitools.openapidiff.core.model.Changed;
+import org.openapitools.openapidiff.core.model.ChangedSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Holds schema created by jonathan.hess@gmail.com */
+public class DeferredSchemaCache {
+  private static final Logger log = LoggerFactory.getLogger(DeferredSchemaCache.class);
+
+  private Map<CacheKey, SchemaDiffOperation> cache = new LinkedHashMap<>();
+  private Queue<CacheKey> processingQueue = new ArrayDeque<>();
+  //    private Queue<DeferredOperation> deferredOperations = new ArrayDeque<>();
+
+  private final OpenApiDiff openApiDiff;
+
+  public DeferredSchemaCache(OpenApiDiff openApiDiff) {
+    this.openApiDiff = openApiDiff;
+  }
+
+  public SchemaDiffOperation addSchema(
+      RecursiveSchemaSet refSet, CacheKey key, Schema left, Schema right) {
+    if (!cache.containsKey(key)) {
+      log.debug("Added schema cache {}", key);
+      SchemaDiffOperation operation =
+          new SchemaDiffOperation(openApiDiff, refSet, key, left, right);
+      cache.put(key, operation);
+      processingQueue.add(key);
+      return operation;
+    } else {
+      return cache.get(key);
+    }
+  }
+
+  public DeferredChanged<ChangedSchema> getOrAddSchema(
+      RecursiveSchemaSet refSet, CacheKey key, Schema left, Schema right) {
+    // don't allow recursive references to schemas
+    if (refSet.contains(key)) {
+      log.debug("getOrAddSchema recursive call aborted {} ", key);
+      return DeferredChanged.empty();
+    }
+
+    refSet.put(key);
+    SchemaDiffOperation operation;
+    if (cache.containsKey(key)) {
+      operation = cache.get(key);
+      log.debug("getOrAddSchema cached {} {}", key, operation.diffResult);
+    } else {
+      operation = addSchema(refSet, key, left, right);
+      log.debug("getOrAddSchema added {} {}", key, operation.diffResult);
+    }
+    return operation.diffResult;
+  }
+
+  public void process() {
+    processSchemaQueue();
+    //        while(! deferredOperations.isEmpty()) {
+    //            processSchemaQueue();
+    //            DeferredOperation op = deferredOperations.poll();
+    //            if(op != null) {
+    //                log.debug("Processing deferred {}", op);
+    //                op.process();
+    //            }
+    //        }
+  }
+
+  public void processSchemaQueue() {
+    PendingChanged.logResolved();
+    while (!processingQueue.isEmpty()) {
+      CacheKey key = processingQueue.poll();
+      if (key != null) {
+        log.debug("Processing schema {}", key);
+        SchemaDiffOperation operation = cache.get(key);
+        DeferredChanged<ChangedSchema> realValue =
+            operation
+                .openApiDiff
+                .getSchemaDiff()
+                .computeDiffForReal(
+                    operation.refSet, operation.left, operation.right, key.getContext());
+        operation.processed = true;
+        realValue.whenSet(
+            (value) -> {
+              log.debug("Schema processed {} {}", key, DeferredLogger.logValue(value));
+              operation.diffResult.setValue(value);
+            });
+        log.debug("Processing schema started {}", key);
+      }
+      PendingChanged.logResolved();
+    }
+  }
+
+  public Collection<SchemaDiffOperation> getOperations() {
+    return cache.values();
+  }
+
+  public List<ChangedSchema> getChangedSchemas() {
+    return cache.values().stream()
+        .filter(op -> op.processed && op.diffResult.isPresent())
+        .map(op -> op.diffResult.get())
+        .collect(Collectors.toList());
+  }
+
+  private static class DeferredOperation<T extends Changed> {
+    private PendingChanged<T> pending = new PendingChanged<>();
+    private final Supplier<Optional<T>> supplier;
+
+    public DeferredOperation(Supplier<Optional<T>> supplier) {
+      this.supplier = supplier;
+    }
+
+    public void process() {
+      pending.setValue(supplier.get());
+    }
+  }
+}

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/PendingChanged.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/PendingChanged.java
@@ -1,0 +1,169 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PendingChanged<T> implements DeferredChanged<T> {
+  private static final Logger log = LoggerFactory.getLogger(PendingChanged.class);
+
+  private List<Consumer<T>> ifPresentConsumers = new ArrayList<>();
+  private List<Consumer<Optional<T>>> whenSetConsumers = new ArrayList<>();
+
+  @Nullable private T value;
+  private Optional<T> valueOptional = Optional.empty();
+  private boolean valueIsPresent;
+  private boolean valueSet;
+
+  private static final AtomicInteger deferredCounter = new AtomicInteger();
+  private static final AtomicInteger resolvedCounter = new AtomicInteger();
+
+  @Override
+  public void ifPresent(Consumer<T> consumer) {
+    if (valueSet) {
+      if (valueIsPresent) {
+        consumer.accept(value);
+      }
+    } else {
+      ifPresentConsumers.add(consumer);
+    }
+  }
+
+  public void setValue(Optional<T> value) {
+    if (!valueSet) {
+      this.valueSet = true;
+      this.valueIsPresent = value.isPresent();
+      this.value = value.orElse(null);
+      this.valueOptional = value;
+
+      log.debug("set {}", DeferredLogger.logValue(this.value));
+
+      if (this.valueIsPresent) {
+        ifPresentConsumers.forEach(c -> c.accept(this.value));
+      }
+
+      whenSetConsumers.forEach(c -> c.accept(this.valueOptional));
+
+    } else {
+      throw new IllegalStateException(
+          "PendingChanged may not be set more than once. Value was already set.");
+    }
+  }
+
+  public boolean isPresent() {
+    return valueSet && valueIsPresent;
+  }
+
+  public T get() {
+    return valueOptional.get();
+  }
+
+  public boolean isValueSet() {
+    return valueSet;
+  }
+
+  public void whenSet(Consumer<Optional<T>> consumer) {
+    if (valueSet) {
+      consumer.accept(valueOptional);
+    } else {
+      whenSetConsumers.add(consumer);
+    }
+  }
+
+  public <Q> DeferredChanged<Q> map(Function<Optional<T>, Q> function) {
+    return mapOptional((v) -> Optional.ofNullable(function.apply(v)));
+  }
+
+  public <Q> DeferredChanged<Q> mapOptional(Function<Optional<T>, Optional<Q>> function) {
+    if (valueSet) {
+      Optional<Q> result = function.apply(this.valueOptional);
+      log.debug(
+          "map resolved {} {} -> {}",
+          function,
+          DeferredLogger.logValue(this.value),
+          DeferredLogger.logValue(result));
+      return new RealizedChanged<Q>(result);
+    } else {
+      final PendingChanged<Q> mappedChanged = new PendingChanged();
+      log.debug("map deferred {} ? -> ?", function);
+      deferredCounter.incrementAndGet();
+      whenSet(
+          (value) -> {
+            Optional<Q> result = function.apply(this.valueOptional);
+            log.debug(
+                "map resolved {} {} -> {}",
+                function,
+                DeferredLogger.logValue(this.value),
+                DeferredLogger.logValue(result));
+            resolvedCounter.incrementAndGet();
+            mappedChanged.setValue(result);
+          });
+      return mappedChanged;
+    }
+  }
+
+  public <Q> DeferredChanged<Q> flatMap(Function<Optional<T>, DeferredChanged<Q>> function) {
+    if (valueSet) {
+      DeferredChanged<Q> nextDeferred = function.apply(this.valueOptional);
+      log.debug("flat map deferred {} {} -> ?", function, DeferredLogger.logValue(this.value));
+      deferredCounter.incrementAndGet();
+      nextDeferred.whenSet(
+          (nextValue) -> {
+            log.debug(
+                "flat map resolved {} {} -> {}",
+                function,
+                DeferredLogger.logValue(this.value),
+                DeferredLogger.logValue(nextValue));
+            resolvedCounter.incrementAndGet();
+          });
+      return nextDeferred;
+    } else {
+      final PendingChanged<Q> mappedChanged = new PendingChanged<>();
+      log.debug("flat map deferred {} ? -> ?", function);
+      deferredCounter.incrementAndGet();
+      whenSet(
+          (value) -> {
+            DeferredChanged<Q> nextDeferred = function.apply(value);
+            nextDeferred.whenSet(
+                (nextValue) -> {
+                  log.debug(
+                      "flat map deferred {} {} -> {}",
+                      function,
+                      DeferredLogger.logValue(this.value),
+                      DeferredLogger.logValue(nextValue));
+                  resolvedCounter.incrementAndGet();
+                  mappedChanged.setValue(nextValue);
+                });
+            log.debug("flat map resolved {} {} -> ?", function, DeferredLogger.logValue(value));
+          });
+      return mappedChanged;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "PendingChanged{"
+        + "value="
+        + DeferredLogger.logValue(value)
+        + ", valueSet="
+        + valueSet
+        + ", ifPresentConsumers.size="
+        + ifPresentConsumers.size()
+        + ", whenSetConsumers.size="
+        + whenSetConsumers.size()
+        + '}';
+  }
+
+  public static void logResolved() {
+    int deferred = deferredCounter.get();
+    int resolved = resolvedCounter.get();
+    log.debug(
+        "Outstanding: {}  Deferred: {}  Resolved {}", deferred - resolved, deferred, resolved);
+  }
+}

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/RealizedChanged.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/RealizedChanged.java
@@ -1,0 +1,64 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class RealizedChanged<T> implements DeferredChanged<T> {
+  private final Optional<T> value;
+
+  public RealizedChanged(T value) {
+    this.value = Optional.ofNullable(value);
+  }
+
+  public RealizedChanged(Optional<T> value) {
+    this.value = value;
+  }
+
+  @Override
+  public void ifPresent(Consumer<T> consumer) {
+    value.ifPresent(consumer);
+  }
+
+  @Override
+  public void whenSet(Consumer<Optional<T>> consumer) {
+    consumer.accept(value);
+  }
+
+  public static <T> RealizedChanged<T> empty() {
+    return new RealizedChanged(Optional.empty());
+  }
+
+  @Override
+  public boolean isPresent() {
+    return value.isPresent();
+  }
+
+  @Override
+  public boolean isValueSet() {
+    return true;
+  }
+
+  @Override
+  public T get() {
+    return value.get();
+  }
+
+  public <Q> DeferredChanged<Q> map(Function<Optional<T>, Q> function) {
+    return new RealizedChanged<Q>(function.apply(this.value));
+  }
+
+  @Override
+  public <Q> DeferredChanged<Q> mapOptional(Function<Optional<T>, Optional<Q>> consumer) {
+    return new RealizedChanged<>(consumer.apply(this.value));
+  }
+
+  public <Q> DeferredChanged<Q> flatMap(Function<Optional<T>, DeferredChanged<Q>> function) {
+    return function.apply(this.value);
+  }
+
+  @Override
+  public String toString() {
+    return "RealizedChanged{" + "value=" + value + '}';
+  }
+}

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/RecursiveSchemaSet.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/RecursiveSchemaSet.java
@@ -1,0 +1,18 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import java.util.HashSet;
+import org.openapitools.openapidiff.core.compare.CacheKey;
+
+public class RecursiveSchemaSet {
+  HashSet<String> leftKeys = new HashSet<>();
+  HashSet<String> rightKeys = new HashSet<>();
+
+  public boolean contains(CacheKey key) {
+    return leftKeys.contains(key.getLeft()) || rightKeys.contains(key.getRight());
+  }
+
+  public void put(CacheKey key) {
+    leftKeys.add(key.getLeft());
+    leftKeys.add(key.getRight());
+  }
+}

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/SchemaDiffOperation.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/SchemaDiffOperation.java
@@ -1,0 +1,26 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import io.swagger.v3.oas.models.media.Schema;
+import org.openapitools.openapidiff.core.compare.CacheKey;
+import org.openapitools.openapidiff.core.compare.OpenApiDiff;
+import org.openapitools.openapidiff.core.model.ChangedSchema;
+
+public class SchemaDiffOperation {
+  final OpenApiDiff openApiDiff;
+  final RecursiveSchemaSet refSet;
+  final CacheKey key;
+  final Schema left;
+  final Schema right;
+  boolean processed;
+
+  PendingChanged<ChangedSchema> diffResult = new PendingChanged<>();
+
+  SchemaDiffOperation(
+      OpenApiDiff openApiDiff, RecursiveSchemaSet refSet, CacheKey key, Schema left, Schema right) {
+    this.openApiDiff = openApiDiff;
+    this.refSet = refSet;
+    this.key = key;
+    this.left = left;
+    this.right = right;
+  }
+}

--- a/core/src/test/java/org/openapitools/openapidiff/core/LargeSchemaTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/LargeSchemaTest.java
@@ -1,0 +1,163 @@
+package org.openapitools.openapidiff.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiAreEquals;
+import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiBackwardIncompatible;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+import org.slf4j.Logger;
+
+/** Created by jonathan.hess on 2020-07-16. */
+public class LargeSchemaTest {
+  public static final Logger LOG = getLogger(LargeSchemaTest.class);
+
+  @Test
+  public void testGeneratedApiSame() {
+    OpenAPI generated = largeGeneratedApi();
+    assertOpenApiAreEquals(generated, generated);
+  }
+
+  @Test
+  public void testGeneratedApiDifferent() {
+    OpenAPI generated = largeGeneratedApi();
+    OpenAPI generated2 = largeGeneratedApi();
+    assertOpenApiBackwardIncompatible(generated, generated2);
+  }
+
+  public static void assertOpenApiAreEquals(OpenAPI oldSpec, OpenAPI newSpec) {
+    ChangedOpenApi changedOpenApi = OpenApiCompare.fromSpecifications(oldSpec, newSpec);
+    LOG.info("Result: {}", changedOpenApi.isChanged().getValue());
+    assertThat(changedOpenApi.getNewEndpoints()).isEmpty();
+    assertThat(changedOpenApi.getMissingEndpoints()).isEmpty();
+    assertThat(changedOpenApi.getChangedOperations()).isEmpty();
+  }
+
+  public static void assertOpenApiBackwardIncompatible(OpenAPI oldSpec, OpenAPI newSpec) {
+    ChangedOpenApi changedOpenApi = OpenApiCompare.fromSpecifications(oldSpec, newSpec);
+    LOG.info("Result: {}", changedOpenApi.isChanged().getValue());
+    assertThat(changedOpenApi.isDifferent()).isTrue();
+    assertThat(changedOpenApi.isIncompatible()).isTrue();
+  }
+
+  public OpenAPI largeGeneratedApi() {
+    final int modelCount = 200;
+    final int arrayCount = 50;
+    final int refPerModelCount = 5;
+    final int endpointCount = 20;
+
+    Random random = new Random();
+
+    OpenAPI api = new OpenAPI();
+    api.setPaths(new Paths());
+    api.setComponents(new Components());
+
+    // create 200 model schemas
+    Map<String, Schema> schemas = new LinkedHashMap<>();
+    api.getComponents().setSchemas(schemas);
+    for (int i = 0; i < modelCount; i++) {
+      ObjectSchema schema = new ObjectSchema();
+      schema.setProperties(new LinkedHashMap<>());
+      schema.getProperties().put("name", new StringSchema());
+      schema.getProperties().put("description", new StringSchema());
+      List<String> required = new ArrayList<>();
+      required.add("name");
+      schema.setRequired(required);
+      schemas.put(modelName(i), schema);
+    }
+
+    // create 50 array schemas
+    for (int i = modelCount; i < modelCount + arrayCount; i++) {
+      ArraySchema arraySchema = new ArraySchema();
+      arraySchema.setItems(refSchema(i));
+      schemas.put(modelName(i), arraySchema);
+    }
+
+    // list of schema names
+
+    // Create cyclic properties on schemas, make the refs required
+    schemas.values().stream()
+        .filter(schema -> schema instanceof ObjectSchema)
+        .map(schema -> (ObjectSchema) schema)
+        .forEach(
+            schema -> {
+              for (int i = 0; i < refPerModelCount; i++) {
+                int schemaNumber = random.nextInt(modelCount + arrayCount);
+                String propertyName = "refTo" + schemaNumber;
+                schema.getProperties().put(propertyName, refSchema(schemaNumber));
+                schema.getRequired().add(propertyName);
+              }
+            });
+
+    // generated endpoints
+    for (int i = 0; i < endpointCount; i++) {
+      String path = "/endpoint" + i;
+      PathItem pathItem = new PathItem();
+      Operation operation = new Operation();
+      pathItem.post(operation);
+
+      operation.setRequestBody(
+          new RequestBody()
+              .content(
+                  new Content()
+                      .addMediaType(
+                          "application/json", new MediaType().schema(refSchema(i % modelCount)))));
+      ApiResponse responseOk =
+          new ApiResponses()
+              .put(
+                  "200",
+                  new ApiResponse()
+                      .content(
+                          new Content()
+                              .addMediaType(
+                                  "application/json",
+                                  new MediaType().schema(refSchema(i % modelCount)))));
+      ApiResponses responses = new ApiResponses();
+      responses.put("200", responseOk);
+      operation.setResponses(responses);
+      api.getPaths().put(path, pathItem);
+    }
+
+    try {
+      LOG.info("Printing schema to target/large-api.yaml");
+      Yaml.pretty().writeValue(new File("target/large-api.yaml"), api);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return api;
+  }
+
+  private Schema refSchema(final int i) {
+    String itemModelName = modelName(i);
+    Schema refSchema = new Schema();
+    refSchema.set$ref("#/components/schemas/" + itemModelName);
+    return refSchema;
+  }
+
+  private String modelName(final int i) {
+    return String.format("Model%03d", i);
+  }
+}

--- a/core/src/test/java/org/openapitools/openapidiff/core/OneOfDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/OneOfDiffTest.java
@@ -44,6 +44,7 @@ public class OneOfDiffTest {
   public void testComposedSchemaDiff() {
     assertOpenApiAreEquals(OPENAPI_DOC10, OPENAPI_DOC10);
   }
+
   @Test
   public void testOneOfDiscrimitatorChanged() {
     // The oneOf 'discriminator' changed: 'realtype' -> 'othertype':

--- a/core/src/test/java/org/openapitools/openapidiff/core/PathDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/PathDiffTest.java
@@ -30,7 +30,9 @@ public class PathDiffTest {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_PATH1, OPENAPI_PATH4);
     assertThat(changedOpenApi.getNewEndpoints())
         .hasSize(1)
-        .satisfiesExactly(endpoint -> assertThat(endpoint.getOperation().getOperationId()).isEqualTo("deletePet"));
+        .satisfiesExactly(
+            endpoint ->
+                assertThat(endpoint.getOperation().getOperationId()).isEqualTo("deletePet"));
     assertThat(changedOpenApi.isCompatible()).isTrue();
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/RecursiveSchemaTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/RecursiveSchemaTest.java
@@ -10,10 +10,16 @@ public class RecursiveSchemaTest {
 
   private final String OPENAPI_DOC1 = "recursive_model_1.yaml";
   private final String OPENAPI_DOC2 = "recursive_model_2.yaml";
+  private final String OPENAPI_DOC3 = "recursive_model_3.yaml";
 
   @Test
   public void testDiffSame() {
     assertOpenApiAreEquals(OPENAPI_DOC1, OPENAPI_DOC1);
+  }
+
+  @Test
+  public void testDiffDifferentCyclic() {
+    assertOpenApiBackwardIncompatible(OPENAPI_DOC1, OPENAPI_DOC3);
   }
 
   @Test

--- a/core/src/test/java/org/openapitools/openapidiff/core/SecurityDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/SecurityDiffTest.java
@@ -91,7 +91,7 @@ public class SecurityDiffTest {
         IllegalArgumentException.class,
         () -> OpenApiCompare.fromLocations(OPENAPI_DOC3, OPENAPI_DOC3));
     assertThrows(
-            IllegalArgumentException.class,
-            () -> OpenApiCompare.fromLocations(OPENAPI_DOC4, OPENAPI_DOC4));
+        IllegalArgumentException.class,
+        () -> OpenApiCompare.fromLocations(OPENAPI_DOC4, OPENAPI_DOC4));
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/compare/ApiResponseDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/compare/ApiResponseDiffTest.java
@@ -1,27 +1,27 @@
 package org.openapitools.openapidiff.core.compare;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiBackwardCompatible;
 import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiBackwardIncompatible;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class ApiResponseDiffTest extends Assertions {
-    /***
-     * This is a regression test - when no responses were set, we would get an exception
-     * since the OpenAPI object has a `null` ApiResponses field.
-     */
-    @Test
-    public void testNoResponseInPrevious() {
-        // The previous API had no response, so adding a response shape is still compatible.
-        assertOpenApiBackwardCompatible(
-                "backwardCompatibility/apiResponse_diff_1.yaml",
-                "backwardCompatibility/apiResponse_diff_2.yaml", true);
+  /**
+   * * This is a regression test - when no responses were set, we would get an exception since the
+   * OpenAPI object has a `null` ApiResponses field.
+   */
+  @Test
+  public void testNoResponseInPrevious() {
+    // The previous API had no response, so adding a response shape is still compatible.
+    assertOpenApiBackwardCompatible(
+        "backwardCompatibility/apiResponse_diff_1.yaml",
+        "backwardCompatibility/apiResponse_diff_2.yaml",
+        true);
 
-        // Removing the response shape is backwards incompatible.
-        assertOpenApiBackwardIncompatible(
-                "backwardCompatibility/apiResponse_diff_2.yaml",
-                "backwardCompatibility/apiResponse_diff_1.yaml");
-    }
+    // Removing the response shape is backwards incompatible.
+    assertOpenApiBackwardIncompatible(
+        "backwardCompatibility/apiResponse_diff_2.yaml",
+        "backwardCompatibility/apiResponse_diff_1.yaml");
+  }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/model/deferred/DeferredBuilderChangedTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/model/deferred/DeferredBuilderChangedTest.java
@@ -1,0 +1,175 @@
+package org.openapitools.openapidiff.core.model.deferred;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openapitools.openapidiff.core.model.schema.ChangedReadOnly;
+import org.openapitools.openapidiff.core.model.schema.ChangedWriteOnly;
+
+public class DeferredBuilderChangedTest {
+
+  private PendingChanged<ChangedReadOnly> changed;
+  private Optional<ChangedReadOnly> whenSet;
+  private ChangedWriteOnly mappedValue;
+  private Optional chainedValue;
+
+  @BeforeEach
+  public void beforeEach() {
+    whenSet = Optional.empty();
+    mappedValue = null;
+    chainedValue = Optional.empty();
+    changed = new PendingChanged<>();
+  }
+
+  @Test
+  public void testPendingChangedValueSetBeforeListeners() {
+    PendingChanged<String> changed = new PendingChanged();
+    changed.setValue(Optional.of("Hello"));
+    ChangedAssertion assertion = new ChangedAssertion(changed);
+    assertion.assertSet(true);
+  }
+
+  @Test
+  public void testPendingChangedValueSetAfterListeners() {
+    PendingChanged<String> changed = new PendingChanged();
+    ChangedAssertion assertion = new ChangedAssertion(changed);
+    changed.setValue(Optional.of("Hello"));
+    assertion.assertSet(true);
+  }
+
+  @Test
+  public void testPendingChangedValueEMpty() {
+    PendingChanged<String> changed = new PendingChanged();
+    ChangedAssertion assertion = new ChangedAssertion(changed);
+    changed.setValue(Optional.empty());
+    assertion.assertSet(false);
+  }
+
+  @Test
+  public void testRealizedChange() {
+    RealizedChanged<String> changed = new RealizedChanged<>("hello");
+    ChangedAssertion assertion = new ChangedAssertion(changed);
+    assertion.assertSet(true);
+  }
+
+  @Test
+  public void testRealizedChangeEmpty() {
+    RealizedChanged<String> changed = new RealizedChanged<>(Optional.empty());
+    ChangedAssertion assertion = new ChangedAssertion(changed);
+    assertion.assertSet(false);
+  }
+
+  private static class ChangedAssertion {
+    AtomicBoolean map = new AtomicBoolean(false);
+    AtomicBoolean flatMap = new AtomicBoolean(false);
+    AtomicBoolean mapOptional = new AtomicBoolean(false);
+    AtomicBoolean whenSet = new AtomicBoolean(false);
+    AtomicBoolean ifPresent = new AtomicBoolean(false);
+
+    public ChangedAssertion(DeferredChanged changed) {
+      changed.mapOptional(
+          (value) -> {
+            mapOptional.set(true);
+            return Optional.empty();
+          });
+      changed.map(
+          (value) -> {
+            map.set(true);
+            return Optional.empty();
+          });
+      changed.flatMap(
+          (value) -> {
+            flatMap.set(true);
+            return DeferredChanged.empty();
+          });
+      changed.whenSet(
+          (value) -> {
+            whenSet.set(true);
+          });
+      changed.ifPresent(
+          (value) -> {
+            ifPresent.set(true);
+          });
+    }
+
+    public void assertSet(boolean expectedIfPresent) {
+      Assertions.assertTrue(mapOptional.get(), "mapOptional");
+      Assertions.assertTrue(map.get(), "map");
+      Assertions.assertTrue(flatMap.get(), "flatMap");
+      Assertions.assertTrue(whenSet.get(), "whenSet");
+      Assertions.assertEquals(expectedIfPresent, ifPresent.get(), "ifPresent");
+    }
+
+    public void assertNotSet() {
+      Assertions.assertFalse(mapOptional.get(), "mapOptional");
+      Assertions.assertFalse(map.get(), "map");
+      Assertions.assertFalse(flatMap.get(), "flatMap");
+      Assertions.assertFalse(whenSet.get(), "whenSet");
+      Assertions.assertFalse(ifPresent.get(), "ifPresent");
+    }
+  }
+
+  @Test
+  public void testFlatMap() {
+    PendingChanged<ChangedWriteOnly> flatMapPending = new PendingChanged<>();
+
+    changed.whenSet((value) -> this.whenSet = value);
+
+    DeferredChanged<ChangedWriteOnly> chainedChanged =
+        changed.flatMap(
+            (value) -> {
+              System.out.println("Flatmap called");
+              return flatMapPending;
+            });
+    chainedChanged.whenSet(value -> chainedValue = value);
+
+    DeferredChanged<ChangedWriteOnly> mappedDeferred =
+        changed.map(value -> new ChangedWriteOnly(false, true, null));
+    mappedDeferred.ifPresent(v -> mappedValue = v);
+
+    Assertions.assertFalse(whenSet.isPresent());
+    Assertions.assertFalse(chainedValue.isPresent());
+    Assertions.assertNull(mappedValue);
+
+    changed.setValue(Optional.of(new ChangedReadOnly(false, true, null)));
+    Assertions.assertTrue(whenSet.isPresent());
+    Assertions.assertNotNull(mappedValue);
+    Assertions.assertFalse(chainedValue.isPresent());
+
+    flatMapPending.setValue(Optional.of(new ChangedWriteOnly(false, true, null)));
+    Assertions.assertTrue(whenSet.isPresent());
+    Assertions.assertTrue(chainedValue.isPresent());
+  }
+
+  @Test
+  public void testDeferredBuilderEmpty() {
+    DeferredBuilder builder = new DeferredBuilder();
+    ChangedAssertion builderAssertion = new ChangedAssertion(builder.build());
+    builderAssertion.assertSet(false);
+  }
+
+  @Test
+  public void testDeferredBuilderAllRealized() {
+    DeferredBuilder builder = new DeferredBuilder();
+    builder.add(new RealizedChanged("hello"));
+    builder.add(new RealizedChanged("bye"));
+    ChangedAssertion builderAssertion = new ChangedAssertion(builder.build());
+    builderAssertion.assertSet(true);
+  }
+
+  @Test
+  public void testDeferredBuilderPending() {
+    PendingChanged<String> changed = new PendingChanged();
+
+    DeferredBuilder builder = new DeferredBuilder();
+    builder.add(new RealizedChanged("hello"));
+    builder.add(changed);
+    ChangedAssertion builderAssertion = new ChangedAssertion(builder.build());
+    builderAssertion.assertNotSet();
+
+    changed.setValue(Optional.of("hello"));
+    builderAssertion.assertSet(true);
+  }
+}

--- a/core/src/test/resources/recursive_model_3.yaml
+++ b/core/src/test/resources/recursive_model_3.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: recursive test
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000/'
+paths:
+  /ping:
+    get:
+      operationId: ping
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/B'
+components:
+  schemas:
+    B:
+      type: object
+      properties:
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/C'
+    C:
+      type: object
+      properties:
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/B'


### PR DESCRIPTION
## Why 

My employer has an API schema with a lot of deeply nested and
recursively referenced objects. We wanted to validate that changes made
by developers are backwards compatible. Unfortunately the OpenAPI-Diff
tool would run practically forever. There were too many situations
where it would have to recompute a diff and could not use the cached
result.

I implemented an approach that defers computing schema diffs until
the entire structure of the API schema has been parsed. This prevents
recursive schema definitions from being computed over and over again
during parsing. It also ensures that diffs are only computed exactly
one time, not recomputed.

All this reduces the computational complexity of parsing this big,
recursive schema to a manageable time, and avoids recomputing diffs.

## Test case

I have created a test case: `LargeSchemaTest` that generates a schema
similar to the one my employer uses. (Unfortunately our schema is for
an internal system and I can't share it.)

It will generate similar, but incompatible schemas. These schemas each
have:
- 250 schemas defined in #/components/schemas, each with 5 properties
  recursively referencing other schemas defined in #/components schemas.
- 100 api endpoints that use those schemas in the RequestBody or
  ResponseBody.

When this test on the `master` branch openapi-diff code, it will not
complete. When you profile, you will find that the time is spent
in `Changed.isChanged()` which recursively calls other instances of
`Changed`. The deep recursion causes an exponential explosion of the
number of calls required to compute changed for the whole model.

## The solution: Deferring computation of diffs

The solution is to break the diff into a two step process:
- Step 1: Read the schema and align all the diff computations, deferring
  computation of actual differences, and avoiding recursive differences.
- Step 2: Compute all the differences, avoiding recomputing the
  recursive differences.

This is implemented in [OpenApiDiff.compare()](core/src/main/java/org/openapitools/openapidiff/core/compare/OpenApiDiff.java#L89-L127)]

Implementing this was a relatively small change to the code.
The `DeferredSchemaCache` holds the cache of SchemaDiffs. It is able to
distinguish multiple requests for the same differences. This is the
key to avoiding recomputing the same difference multiple times.

I replaced all the `Optional<?> diff(...)` with `DeferredChanged<?> diff(...)`,
and chose an interface for `DeferredChanged` that matched the `Optional`
interface. This minimized the lines of code changed, making it easier
to review.

Finally, I created a helper object called `DeferredBuilder` which
simplifies the task of collecting a bunch of `DeferedChanged` instances
together to make composing a change easier to program and read.

