### PR TITLE
Reverts behaviour for PUT operations with new attributes.

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedSchema.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedSchema.java
@@ -1,6 +1,5 @@
 package org.openapitools.openapidiff.core.model;
 
-import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -75,24 +74,16 @@ public class ChangedSchema implements ComposedChanged {
         && !discriminatorPropertyChanged) {
       return DiffResult.NO_CHANGES;
     }
+    boolean compatibleForRequest = (oldSchema != null || newSchema == null);
     boolean compatibleForResponse =
         missingProperties.isEmpty() && (oldSchema == null || newSchema != null);
-    if ((context.isRequest() && compatibleForRequest()
+    if ((context.isRequest() && compatibleForRequest
             || context.isResponse() && compatibleForResponse)
         && !changedType
         && !discriminatorPropertyChanged) {
       return DiffResult.COMPATIBLE;
     }
     return DiffResult.INCOMPATIBLE;
-  }
-
-  private boolean compatibleForRequest() {
-    if (PathItem.HttpMethod.PUT.equals(context.getMethod())) {
-      if (increasedProperties.size() > 0) {
-        return false;
-      }
-    }
-    return (oldSchema != null || newSchema == null);
   }
 
   public DiffContext getContext() {

--- a/core/src/test/java/org/openapitools/openapidiff/core/AddPropPutDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/AddPropPutDiffTest.java
@@ -1,7 +1,7 @@
 package org.openapitools.openapidiff.core;
 
 import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiAreEquals;
-import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiBackwardIncompatible;
+import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiBackwardCompatible;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +16,7 @@ public class AddPropPutDiffTest {
   }
 
   @Test
-  public void testDiffDifferent() {
-    assertOpenApiBackwardIncompatible(OPENAPI_DOC1, OPENAPI_DOC2);
+  public void testDiffReportsNonBreakingChange() {
+    assertOpenApiBackwardCompatible(OPENAPI_DOC1, OPENAPI_DOC2, true);
   }
 }


### PR DESCRIPTION
Logically reverts 25bd1544c70832a68a3f80da28b92c7ad285d886 which was added due to https://github.com/OpenAPITools/openapi-diff/issues/136

Issue raised to deal with this permanently in the OpenAPITools repository is https://github.com/OpenAPITools/openapi-diff/issues/251