### PR TITLE
Add JsonRender and --json command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Compare two OpenAPI specifications (3.x) and render the difference to HTML plain
 * Depth comparison of parameters, responses, endpoint, http method (GET,POST,PUT,DELETE...)
 * Supports swagger api Authorization
 * Render difference of property with Expression Language
-* HTML & Markdown render
+* HTML, Markdown & JSON render
 
 # Maven
 
@@ -52,6 +52,7 @@ usage: openapi-diff <old> <new>
     --header <property=value>   use given header for authorisation
     --html <file>               export diff as html in given file
     --info                      Print additional information
+    --json <file>               export diff as json in given file
  -l,--log <level>               use given level for log (TRACE, DEBUG,
                                 INFO, WARN, ERROR, OFF). Default: ERROR
     --markdown <file>           export diff as markdown in given file
@@ -104,6 +105,7 @@ usage: openapi-diff <old> <new>
     --header <property=value>   use given header for authorisation
     --html <file>               export diff as html in given file
     --info                      Print additional information
+    --json <file>               export diff as json in given file
  -l,--log <level>               use given level for log (TRACE, DEBUG,
                                 INFO, WARN, ERROR, OFF). Default: ERROR
     --markdown <file>           export diff as markdown in given file
@@ -160,6 +162,22 @@ String render = new MarkdownRender().render(diff);
 try {
     FileWriter fw = new FileWriter(
             "testDiff.md");
+    fw.write(render);
+    fw.close();
+    
+} catch (IOException e) {
+    e.printStackTrace();
+}
+```
+
+
+#### JSON
+
+```java
+String render = new JsonRender().render(diff);
+try {
+    FileWriter fw = new FileWriter(
+            "testDiff.json");
     fw.write(render);
     fw.close();
     
@@ -348,6 +366,71 @@ Then, including your library with the `openapi-diff` module will cause it to be 
     Return Type
 
         Changed response : [200] //successful operation
+```
+
+### JSON
+
+```json
+{
+    "changedElements": [...],
+    "changedExtensions": null,
+    "changedOperations": [...],
+    "compatible": false,
+    "deprecatedEndpoints": [...],
+    "different": true,
+    "incompatible": true,
+    "missingEndpoints": [...],
+    "newEndpoints": [
+        {
+            "method": "GET",
+            "operation": {
+                "callbacks": null,
+                "deprecated": null,
+                "description": "Returns a single pet",
+                "extensions": null,
+                "externalDocs": null,
+                "operationId": "getPetById",
+                "parameters": [
+                    {
+                        "$ref": null,
+                        "allowEmptyValue": null,
+                        "allowReserved": null,
+                        "content": null,
+                        "deprecated": null,
+                        "description": "ID of pet to return",
+                        "example": null,
+                        "examples": null,
+                        "explode": false,
+                        "extensions": null,
+                        "in": "path",
+                        "name": "petId",
+                        "required": true,
+                        "schema": {...},
+                        "style": "SIMPLE"
+                    }
+                ],
+                "requestBody": null,
+                "responses": {...},
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ],
+                "servers": null,
+                "summary": "Find pet by ID",
+                "tags": [
+                    "pet"
+                ]
+            },
+            "path": null,
+            "pathUrl": "/pet/{petId}",
+            "summary": "Find pet by ID"
+        }
+    ],
+    "newSpecOpenApi": {...},
+    "oldSpecOpenApi": {...},
+    "unchanged": false
+}
 ```
 
 # License

--- a/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
+++ b/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
@@ -24,6 +24,7 @@ import org.openapitools.openapidiff.core.OpenApiCompare;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.output.ConsoleRender;
 import org.openapitools.openapidiff.core.output.HtmlRender;
+import org.openapitools.openapidiff.core.output.JsonRender;
 import org.openapitools.openapidiff.core.output.MarkdownRender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,6 +107,13 @@ public class Main {
             .argName("file")
             .desc("export diff as text in given file")
             .build());
+    options.addOption(
+        Option.builder()
+            .longOpt("json")
+            .hasArg()
+            .argName("file")
+            .desc("export diff as json in given file")
+            .build());
 
     // create the parser
     CommandLineParser parser = new DefaultParser();
@@ -186,6 +194,12 @@ public class Main {
       if (line.hasOption("text")) {
         String output = consoleRender.render(result);
         String outputFile = line.getOptionValue("text");
+        writeOutput(output, outputFile);
+      }
+      if (line.hasOption("json")) {
+        JsonRender jsonRender = new JsonRender();
+        String output = jsonRender.render(result);
+        String outputFile = line.getOptionValue("json");
         writeOutput(output, outputFile);
       }
       if (line.hasOption("state")) {

--- a/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
@@ -1,0 +1,18 @@
+package org.openapitools.openapidiff.core.output;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+
+public class JsonRender implements Render {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String render(ChangedOpenApi diff) {
+        try {
+            return objectMapper.writeValueAsString(diff);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Could not serialize diff as JSON", e);
+        }
+    }
+}

--- a/core/src/test/java/org/openapitools/openapidiff/core/JsonRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/JsonRenderTest.java
@@ -1,0 +1,17 @@
+package org.openapitools.openapidiff.core;
+
+import org.junit.jupiter.api.Test;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+import org.openapitools.openapidiff.core.output.JsonRender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonRenderTest {
+  @Test
+  public void renderDoesNotFailWhenPropertyHasBeenRemoved() {
+    JsonRender render = new JsonRender();
+    ChangedOpenApi diff =
+        OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
+    assertThat(render.render(diff)).isNotBlank();
+  }
+}

--- a/core/src/test/java/org/openapitools/openapidiff/core/OpenApiDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/OpenApiDiffTest.java
@@ -11,6 +11,7 @@ import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.model.ChangedOperation;
 import org.openapitools.openapidiff.core.model.Endpoint;
 import org.openapitools.openapidiff.core.output.HtmlRender;
+import org.openapitools.openapidiff.core.output.JsonRender;
 import org.openapitools.openapidiff.core.output.MarkdownRender;
 
 public class OpenApiDiffTest {
@@ -95,6 +96,20 @@ public class OpenApiDiffTest {
     String render = new MarkdownRender().render(diff);
     try {
       FileWriter fw = new FileWriter("target/testDiff.md");
+      fw.write(render);
+      fw.close();
+
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testDiffAndJson() {
+    ChangedOpenApi diff = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_DOC2);
+    String render = new JsonRender().render(diff);
+    try {
+      FileWriter fw = new FileWriter("target/testDiff.json");
       fw.write(render);
       fw.close();
 


### PR DESCRIPTION
We use OpenAPI-diff in a non-Java environment where we want to be able to inspect the generated diff. We currently use a tiny wrapper program that runs `OpenApiCompare.fromLocations`, then serializes the resulting `ChangedOpenApi` to JSON using Jackson. It would be useful to us to drop the wrapper and have this functionality built into OpenAPI-diff instead, similar to the built-in Markdown and HTML rendering.

This pull request adds a new `JsonRender` class and a `--json <file>` command line option which works similarly to the existing `--html`, `--markdown`, and `--text` commands.

The generated JSON is quite large, and it could be useful to clean-up, for example removing `newSpecOpenApi`, `oldSpecOpenApi`, but it's still useful, as long as you parse out the specific parts you need instead of read through the whole thing.

Feel free to make or suggest any needed edits. I do not work too often in Java, so there may be some non-idiomatic parts in the pull request.