### PR TITLE
Fix NullPointerException when diffing security schemes without `components` element

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
@@ -56,6 +56,9 @@ public class SecurityRequirementsDiff {
     return securityRequirement.keySet().stream()
         .map(
             x -> {
+              if (components == null) {
+                throw new IllegalArgumentException("Missing securitySchemes component definition.");
+              }
               Map<String, SecurityScheme> securitySchemes = components.getSecuritySchemes();
               if (securitySchemes == null) {
                 throw new IllegalArgumentException("Missing securitySchemes component definition.");

--- a/core/src/test/java/org/openapitools/openapidiff/core/SecurityDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/SecurityDiffTest.java
@@ -13,6 +13,7 @@ public class SecurityDiffTest {
   private final String OPENAPI_DOC2 = "security_diff_2.yaml";
   private final String OPENAPI_DOC3 = "security_diff_3.yaml";
   private final String OPENAPI_DOC4 = "security_diff_4.yaml";
+  private final String OPENAPI_DOC5 = "security_diff_5.yaml";
 
   @Test
   public void testDiffDifferent() {
@@ -93,5 +94,12 @@ public class SecurityDiffTest {
     assertThrows(
             IllegalArgumentException.class,
             () -> OpenApiCompare.fromLocations(OPENAPI_DOC4, OPENAPI_DOC4));
+  }
+
+  @Test
+  public void testMissingSecurityDefinition() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> OpenApiCompare.fromLocations(OPENAPI_DOC5, OPENAPI_DOC5));
   }
 }

--- a/core/src/test/resources/security_diff_5.yaml
+++ b/core/src/test/resources/security_diff_5.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+paths:
+  '/pet':
+    get:
+      summary: Deletes a pet
+      description: ''
+      operationId: qqq
+      security:
+        - test: []
+      responses:
+        '200':
+          description: Invalid ID supplied
+
+# security components missing
+components: {}


### PR DESCRIPTION
See the test for the situation that was generating errors.