### PR TITLE
Change packaging to maven-plugin

### DIFF
--- a/maven-example/pom.xml
+++ b/maven-example/pom.xml
@@ -28,7 +28,7 @@
                         </goals>
                         <configuration>
                             <oldSpec>${project.basedir}/../maven/src/test/resources/oldspec.yaml</oldSpec>
-                            <newSpec>${project.basedir}/../maven/src/test/resources/oldspec.yaml</newSpec>
+                            <newSpec>${project.basedir}/../maven/src/test/resources/newspec.yaml</newSpec>
                             <failOnIncompatible>true</failOnIncompatible>
                         </configuration>
                     </execution>

--- a/maven-example/pom.xml
+++ b/maven-example/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>openapi-diff-parent</artifactId>
+        <groupId>org.openapitools.openapidiff</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>openapi-diff-maven-example</artifactId>
+    <packaging>jar</packaging>
+
+    <name>openapi-diff-maven-example</name>
+    <description>Example usage of maven plugin for openapi-diff</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools.openapidiff</groupId>
+                <artifactId>openapi-diff-maven</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>diff</goal>
+                        </goals>
+                        <configuration>
+                            <oldSpec>${project.basedir}/../maven/src/test/resources/oldspec.yaml</oldSpec>
+                            <newSpec>${project.basedir}/../maven/src/test/resources/oldspec.yaml</newSpec>
+                            <failOnIncompatible>true</failOnIncompatible>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>openapi-diff-maven</artifactId>
-  <packaging>jar</packaging>
+  <packaging>maven-plugin</packaging>
 
   <name>openapi-diff-maven</name>
   <description>Maven plugin for openapi-diff</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
         <module>core</module>
         <module>cli</module>
         <module>maven</module>
+        <module>maven-example</module>
     </modules>
 
     <groupId>org.openapitools.openapidiff</groupId>


### PR DESCRIPTION
Maven plugin descriptor is not getting correctly generated, therefore example usage of `openapi-diff` with maven fails. 
Changing the packaging fixes the issue. 

Additional maven-example (a plugin verification) is also provided within this PR