### PR TITLE
Skip Git hook repository check to enable build without `.git`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,7 @@
                             <goal>install</goal>
                         </goals>
                         <configuration>
+                            <skipRepositoryCheck>true</skipRepositoryCheck>
                             <hooks>
                                 <pre-commit>
                                     mvn com.coveo:fmt-maven-plugin:format


### PR DESCRIPTION
The build process would fail if the `.git/` directory is missing, e. g. when downloading the repository contents from GitHub in a ZIP archive:
```text
[ERROR] Failed to execute goal io.github.phillipuniverse:githook-maven-plugin:1.0.5:install (default) on project openapi-diff-parent: Not a git repository, could not find a .git/hooks directory anywhere in the hierarchy of /path/to/openapi-diff/target. Turn off this behavior with skipRepositoryCheck=false -> [Help 1]
```

After the change, a missing `.git/` directory doesn't lead to a build failure:
```text
[INFO] --- githook-maven-plugin:1.0.5:install (default) @ openapi-diff-parent ---
[INFO] No .git directory found, skipping plugin execution
```

Refs #299