### PR TITLE
Exclude null properties when rendering JSON

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
@@ -1,11 +1,13 @@
 package org.openapitools.openapidiff.core.output;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 
 public class JsonRender implements Render {
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
   @Override
   public String render(ChangedOpenApi diff) {


### PR DESCRIPTION
The generated JSON diff file is already fairly large for larger API specs, but is made especially large because a lot of unused properties in the objects are serialised as null properties. 

As a comparison:
9.1M out_with_nulls.json
6.2M out_no_nulls.json

This changes that to ignore null value properties when rendering the json. Makes the files smaller, and also more human-readable.