### PR TITLE
Migrate from Log4j 1.2.x to Logback

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
+++ b/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
@@ -1,5 +1,6 @@
 package org.openapitools.openapidiff.cli;
 
+import ch.qos.logback.classic.Level;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
 import java.io.File;
 import java.io.IOException;
@@ -15,8 +16,6 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
 import org.openapitools.openapidiff.core.OpenApiCompare;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.output.ConsoleRender;
@@ -157,7 +156,9 @@ public class Main {
       if (line.hasOption("state")) {
         logLevel = "OFF";
       }
-      LogManager.getRootLogger().setLevel(Level.toLevel(logLevel));
+      ch.qos.logback.classic.Logger root =
+          (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+      root.setLevel(Level.toLevel(logLevel));
 
       if (line.getArgList().size() < 2) {
         throw new ParseException("Missing arguments");

--- a/cli/src/main/resources/log4j.properties
+++ b/cli/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=DEBUG, STDOUT
-log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
-log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
-log4j.appender.STDOUT.layout.ConversionPattern=%-5p [%c] - %m%n
-#log4j.appender.STDOUT.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5p [%c] - %m%n

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,9 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.10</version>
             </dependency>
             <dependency>
                 <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Log4j 1.x has been EOL for several years.