### PR TITLE
fix: mixed up logic around response mediatype addition/removal

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedContent.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedContent.java
@@ -31,7 +31,7 @@ public class ChangedContent implements ComposedChanged {
     if (increased.isEmpty() && missing.isEmpty()) {
       return DiffResult.NO_CHANGES;
     }
-    if (context.isRequest() && missing.isEmpty() || context.isResponse() && increased.isEmpty()) {
+    if (context.isRequest() && missing.isEmpty() || context.isResponse() && missing.isEmpty()) {
       return DiffResult.COMPATIBLE;
     }
     return DiffResult.INCOMPATIBLE;

--- a/core/src/test/java/org/openapitools/openapidiff/core/ContentDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/ContentDiffTest.java
@@ -33,7 +33,7 @@ public class ContentDiffTest {
     ChangedOpenApi changedOpenApi =
         OpenApiCompare.fromLocations(
             "content_type_response_add_1.yaml", "content_type_response_add_2.yaml");
-    assertThat(changedOpenApi.isCompatible()).isFalse();
+    assertThat(changedOpenApi.isCompatible()).isTrue();
   }
 
   @Test
@@ -41,7 +41,7 @@ public class ContentDiffTest {
     ChangedOpenApi changedOpenApi =
         OpenApiCompare.fromLocations(
             "content_type_response_add_2.yaml", "content_type_response_add_1.yaml");
-    assertThat(changedOpenApi.isCompatible()).isTrue();
+    assertThat(changedOpenApi.isCompatible()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Adding a response mediatype is a non-breaking change, as long as pre-existing ones are still compatible. Clients still can requests all existing mediatype via `Accept` header as they have done before.

Removing an existing mediatype on the over hand is a breaking change, because existing client's requesting this response representation (again via `Accept` header) will probably get a `406 Not Acceptable`.