### PR TITLE
Update Docker release action with multi-platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             openapitools/openapi-diff:${{ github.event.inputs.releaseVersion }}
             openapitools/openapi-diff:latest


### PR DESCRIPTION
Update the docker/build-push-action@v2 to include the `platforms: linux/amd64,linux/arm64` argument. This will ensure the Docker release step builds for the arm64 as well as amd64 platforms.