### PR TITLE
Fix: Crashes when parsing diff for very large specs

### DIFF
--- a/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
+++ b/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
@@ -196,9 +196,9 @@ public class Main {
       }
       if (line.hasOption("json")) {
         JsonRender jsonRender = new JsonRender();
-        String output = jsonRender.render(result);
         String outputFile = line.getOptionValue("json");
-        writeOutput(output, outputFile);
+        jsonRender.renderToFile(result, outputFile);
+        System.out.println("Succesfully wrote diff to output file");
       }
       if (line.hasOption("state")) {
         System.out.println(result.isChanged().getValue());

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOpenApi.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOpenApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.openapidiff.core.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.util.List;
 import java.util.Objects;
@@ -8,8 +9,8 @@ import java.util.stream.Stream;
 import org.openapitools.openapidiff.core.utils.EndpointUtils;
 
 public class ChangedOpenApi implements ComposedChanged {
-  private OpenAPI oldSpecOpenApi;
-  private OpenAPI newSpecOpenApi;
+  @JsonIgnore private OpenAPI oldSpecOpenApi;
+  @JsonIgnore private OpenAPI newSpecOpenApi;
   private List<Endpoint> newEndpoints;
   private List<Endpoint> missingEndpoints;
   private List<ChangedOperation> changedOperations;

--- a/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
@@ -3,6 +3,8 @@ package org.openapitools.openapidiff.core.output;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Paths;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 
 public class JsonRender implements Render {
@@ -15,6 +17,16 @@ public class JsonRender implements Render {
       return objectMapper.writeValueAsString(diff);
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Could not serialize diff as JSON", e);
+    }
+  }
+
+  public void renderToFile(ChangedOpenApi diff, String file) {
+    try {
+      objectMapper.writeValue(Paths.get(file).toFile(), diff);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Could not serialize diff as JSON", e);
+    } catch (IOException e) {
+      throw new RuntimeException("Could not write to JSON file", e);
     }
   }
 }


### PR DESCRIPTION
**Issue:**
When calculating diffs between two large Swagger specs(~123k loc) the tool will crash when writing the output to a JSON file. As shown in the screenshot this is due to the tool, first converting the `ChangedOpenAPI` object to a JSON string and then writing this string to a file. Because this string is massive it violates the max UTF16 string size.

<img width="792" alt="Screen Shot 2022-06-22 at 13 55 50" src="https://user-images.githubusercontent.com/15249882/175104668-35e356e0-64d8-46e7-a9b2-3dd96ebee5a1.png">



**Solution:**
Write the diff directly to a the output file and also omit the `oldSpecOpenApi` and `newSpecOpenApi` when writing the output as an optimization. These fields are irrelevant for the diff output.