### PR TITLE
Fix missing architecture on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.releaseVersion }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub


### PR DESCRIPTION
I noticed that the [release of 2.1.0-beta.1 failed](https://github.com/OpenAPITools/openapi-diff/actions/runs/2565520017) due with the following error.

```
Error while loading �g</build/./mvnw: No such file or directory
```

I recreated the issue on a fork and noticed that `linux/arm64` was not an available platform without first enabling docker QEMU. I suspect this was introduced by https://github.com/OpenAPITools/openapi-diff/pull/336
