### PR TITLE
Fix: Markdown and Console renderer fail when processing range HTTP status code e. g. '2XX'

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/output/ConsoleRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/ConsoleRender.java
@@ -118,7 +118,7 @@ public class ConsoleRender implements Render {
   private String itemResponse(String title, String code) {
     StringBuilder sb = new StringBuilder();
     String status = "";
-    if (!code.equals("default")) {
+    if (!code.equals("default") && !code.matches("[1-5]XX")) {
       status = HttpStatus.getReasonPhrase(Integer.parseInt(code));
     }
     sb.append(StringUtils.repeat(' ', 4))

--- a/core/src/main/java/org/openapitools/openapidiff/core/output/MarkdownRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/MarkdownRender.java
@@ -158,7 +158,7 @@ public class MarkdownRender implements Render {
   protected String itemResponse(String title, String code, String description) {
     StringBuilder sb = new StringBuilder();
     String status = "";
-    if (!code.equals("default")) {
+    if (!code.equals("default") && !code.matches("[1-5]XX")) {
       status = HttpStatus.getReasonPhrase(Integer.parseInt(code));
     }
     sb.append(format("%s : **%s %s**\n", title, code, status));

--- a/core/src/test/java/org/openapitools/openapidiff/core/ConsoleRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/ConsoleRenderTest.java
@@ -14,4 +14,12 @@ public class ConsoleRenderTest {
         OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
     assertThat(render.render(diff)).isNotBlank();
   }
+
+  @Test
+  public void renderDoesNotFailWhenHTTPStatusCodeIsRange() {
+    ConsoleRender render = new ConsoleRender();
+    ChangedOpenApi diff =
+        OpenApiCompare.fromLocations("range_statuscode_1.yaml", "range_statuscode_2.yaml");
+    assertThat(render.render(diff)).isNotBlank();
+  }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/MarkdownRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/MarkdownRenderTest.java
@@ -21,4 +21,12 @@ public class MarkdownRenderTest {
     ChangedOpenApi diff = OpenApiCompare.fromLocations("recursive_old.yaml", "recursive_new.yaml");
     assertThat(render.render(diff)).isNotBlank();
   }
+
+  @Test
+  public void renderDoesNotFailWhenHTTPStatusCodeIsRange() {
+    MarkdownRender render = new MarkdownRender();
+    ChangedOpenApi diff =
+        OpenApiCompare.fromLocations("range_statuscode_1.yaml", "range_statuscode_2.yaml");
+    assertThat(render.render(diff)).isNotBlank();
+  }
 }

--- a/core/src/test/resources/range_statuscode_1.yaml
+++ b/core/src/test/resources/range_statuscode_1.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /pet/{petId}:
+    get:
+      tags:
+        - pet
+      summary: gets a pet by id
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+      responses:
+        '405':
+          description: Invalid input

--- a/core/src/test/resources/range_statuscode_1.yaml
+++ b/core/src/test/resources/range_statuscode_1.yaml
@@ -3,14 +3,8 @@ info:
   title: Projects API
   version: 1.0.0
 paths:
-  /pet/{petId}:
+  /pet/:
     get:
-      parameters:
-        - name: petId
-          in: path
-          required: true
-          schema:
-            type: integer
       responses:
         "405":
           description: "Invalid input"

--- a/core/src/test/resources/range_statuscode_1.yaml
+++ b/core/src/test/resources/range_statuscode_1.yaml
@@ -1,35 +1,16 @@
 openapi: 3.0.0
-servers:
-  - url: 'http://petstore.swagger.io/v2'
 info:
-  description: >-
-    This is a sample server Petstore server.  You can find out more about
-    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
-    #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
-    `special-key` to test the authorization filters.
+  title: Projects API
   version: 1.0.0
-  title: Swagger Petstore
-  termsOfService: 'http://swagger.io/terms/'
-  contact:
-    email: apiteam@swagger.io
-  license:
-    name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
   /pet/{petId}:
     get:
-      tags:
-        - pet
-      summary: gets a pet by id
-      description: ''
-      operationId: updatePetWithForm
       parameters:
         - name: petId
           in: path
-          description: ID of pet that needs to be updated
           required: true
           schema:
             type: integer
       responses:
-        '405':
-          description: Invalid input
+        "405":
+          description: "Invalid input"

--- a/core/src/test/resources/range_statuscode_2.yaml
+++ b/core/src/test/resources/range_statuscode_2.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /pet/{petId}:
+    get:
+      tags:
+        - pet
+      summary: gets a pet by id
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+      responses:
+        '4XX':
+          description: Invalid input

--- a/core/src/test/resources/range_statuscode_2.yaml
+++ b/core/src/test/resources/range_statuscode_2.yaml
@@ -1,35 +1,16 @@
 openapi: 3.0.0
-servers:
-  - url: 'http://petstore.swagger.io/v2'
 info:
-  description: >-
-    This is a sample server Petstore server.  You can find out more about
-    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
-    #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
-    `special-key` to test the authorization filters.
+  title: Projects API
   version: 1.0.0
-  title: Swagger Petstore
-  termsOfService: 'http://swagger.io/terms/'
-  contact:
-    email: apiteam@swagger.io
-  license:
-    name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
   /pet/{petId}:
     get:
-      tags:
-        - pet
-      summary: gets a pet by id
-      description: ''
-      operationId: updatePetWithForm
       parameters:
         - name: petId
           in: path
-          description: ID of pet that needs to be updated
           required: true
           schema:
             type: integer
       responses:
-        '4XX':
-          description: Invalid input
+        "4XX":
+          description: "Invalid input"

--- a/core/src/test/resources/range_statuscode_2.yaml
+++ b/core/src/test/resources/range_statuscode_2.yaml
@@ -3,14 +3,8 @@ info:
   title: Projects API
   version: 1.0.0
 paths:
-  /pet/{petId}:
+  /pet/:
     get:
-      parameters:
-        - name: petId
-          in: path
-          required: true
-          schema:
-            type: integer
       responses:
         "4XX":
           description: "Invalid input"


### PR DESCRIPTION
# Description
Both Markdown and Console renderer fail when trying to process a range HTTP status code, e. g. '2XX'. So any diff that results in an output including such a status code fails to render for markdown and console.
The error occurs when trying to parse the String HTTP status code into an Integer right here (both in Markdown and Console renderer):
```java
if (!code.equals("default")) {
     // Integer.parseInt(code) fails when passing e. g. '2XX'
    status = HttpStatus.getReasonPhrase(Integer.parseInt(code));
}
```
JSON and HTML renderer are not affected, since they do not try to display the 'reason phrase'. Everything else, the actual diff process etc. is also not affected.

# Expected behavior
Expected ranges of HTTP status codes, like '2XX' covering all codes between 200-299, to be treated like any other HTTP status code, since they have been part of the OpenAPI specification since version [3.0.0](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#patterned-fields-1).

# Has this been tested?
I've added tests to both renderers with a corresponding test specification checking if the renderer fails.

# Checklist:
- [x] Smaller changes are easier to review
- [x] Add test case(s) to cover the change
- [ ] Document the fix in the code to make the code more readable
  *  Not worth a comment 
- [x] Make sure test cases passed after the change
- [x] File a PR with meaningful title, description and commit messages
  * I hope I did.
- [x] Make sure the option "Allow edits from maintainers" in the PR is selected so that the maintainers can update your PRs with minor fixes, if needed.


> A review, feedback and merge is highly appreciated.