### PR TITLE
Register ObjectMapper modules

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
@@ -8,8 +8,13 @@ import java.nio.file.Paths;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 
 public class JsonRender implements Render {
-  private final ObjectMapper objectMapper =
-      new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  private final ObjectMapper objectMapper;
+
+  public JsonRender() {
+    objectMapper = new ObjectMapper();
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    objectMapper.findAndRegisterModules();
+  }
 
   @Override
   public String render(ChangedOpenApi diff) {

--- a/core/src/test/java/org/openapitools/openapidiff/core/JsonRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/JsonRenderTest.java
@@ -14,4 +14,12 @@ public class JsonRenderTest {
         OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
     assertThat(render.render(diff)).isNotBlank();
   }
+
+  @Test
+  public void renderDoesNotFailForJsr310Types() {
+    JsonRender render = new JsonRender();
+    ChangedOpenApi diff =
+        OpenApiCompare.fromLocations("jsr310_property_1.yaml", "jsr310_property_2.yaml");
+    assertThat(render.render(diff)).isNotBlank();
+  }
 }

--- a/core/src/test/resources/jsr310_property_1.yaml
+++ b/core/src/test/resources/jsr310_property_1.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.1
+info:
+  title: Title
+  version: 1.0.0
+  description: Description
+paths:
+  /:
+    get:
+      summary: Simple GET
+      operationId: simpleGet
+      responses:
+        default:
+          description: Default response
+          content:
+            application/json:
+              schema:
+                properties:
+                  someDateTime:
+                    description: Date time
+                    example: 2021-11-03T13:50:47Z
+                    type: string
+                    format: date-time
+      description: Simple GET

--- a/core/src/test/resources/jsr310_property_2.yaml
+++ b/core/src/test/resources/jsr310_property_2.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.1
+info:
+  title: Title
+  version: 1.0.0
+  description: Description
+paths:
+  /:
+    get:
+      summary: Simple GET
+      operationId: simpleGet
+      responses:
+        default:
+          description: Default response
+          content:
+            application/json:
+              schema:
+                properties:
+                  someDateTime:
+                    description: Date time
+                    example: 2021-11-03T13:50:47Z
+                    type: string
+      description: Simple GET


### PR DESCRIPTION
Finding and registering modules can avoid exceptions like  the following:

```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.OffsetDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: org.openapitools.openapidiff.core.model.ChangedOpenApi["changedOperations"]->java.util.ArrayList[0]->org.openapitools.openapidiff.core.model.ChangedOperation["oldOperation"]->io.swagger.v3.oas.models.Operation["responses"]->io.swagger.v3.oas.models.responses.ApiResponses["default"]->io.swagger.v3.oas.models.responses.ApiResponse["content"]->io.swagger.v3.oas.models.media.Content["application/json"]->io.swagger.v3.oas.models.media.MediaType["schema"]->io.swagger.v3.oas.models.media.Schema["properties"]->java.util.LinkedHashMap["someDateTime"]->io.swagger.v3.oas.models.media.DateTimeSchema["example"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:77)
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1300)
	at com.fasterxml.jackson.databind.ser.impl.UnsupportedTypeSerializer.serialize(UnsupportedTypeSerializer.java:35)
...
	at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3821)
	at org.openapitools.openapidiff.core.output.JsonRender.render(JsonRender.java:22)
```