### PR TITLE
Add 2 lf instead of 1 at the end of Markdown blockquotes

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/output/MarkdownRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/MarkdownRender.java
@@ -528,7 +528,7 @@ public class MarkdownRender implements Render {
 
   protected String blockquote(String beginning, String text) {
     String blockquote = blockquote(beginning);
-    return blockquote + text.trim().replace("\n", "\n" + blockquote) + '\n\n';
+    return blockquote + text.trim().replace("\n", "\n" + blockquote) + "\n\n";
   }
 
   protected String type(Schema<?> schema) {

--- a/core/src/main/java/org/openapitools/openapidiff/core/output/MarkdownRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/MarkdownRender.java
@@ -528,7 +528,7 @@ public class MarkdownRender implements Render {
 
   protected String blockquote(String beginning, String text) {
     String blockquote = blockquote(beginning);
-    return blockquote + text.trim().replace("\n", "\n" + blockquote) + '\n';
+    return blockquote + text.trim().replace("\n", "\n" + blockquote) + '\n\n';
   }
 
   protected String type(Schema<?> schema) {


### PR DESCRIPTION
When they weren't headers, the lines following a bloquote are considered as if they were part of the blockquote