### PR TITLE
bugfix (to master): after openapi specs comparison, all parameters are removed

### DIFF
--- a/core/src/test/java/org/openapitools/openapidiff/core/PathDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/PathDiffTest.java
@@ -2,7 +2,6 @@ package org.openapitools.openapidiff.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiAreEquals;
 
 import org.junit.jupiter.api.Test;
@@ -42,13 +41,8 @@ public class PathDiffTest {
   @Test
   public void testDiffWithSimilarBeginningPaths() {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_PATH5, OPENAPI_PATH6);
-    try {
-      ChangedOpenApi diff =
-          OpenApiCompare.fromSpecifications(
-              changedOpenApi.getOldSpecOpenApi(), changedOpenApi.getNewSpecOpenApi());
-      assertThat(diff.getChangedOperations()).hasSize(4);
-    } catch (IllegalArgumentException e) {
-      fail(e.getMessage());
-    }
+    ChangedOpenApi diff = OpenApiCompare.fromSpecifications(
+            changedOpenApi.getOldSpecOpenApi(), changedOpenApi.getNewSpecOpenApi());
+    assertThat(diff.getChangedOperations()).isEmpty();
   }
 }


### PR DESCRIPTION
bugfix: after openapi specs comparison, all parameters are removed from new spec (right side) because of reused parameters list.

- updated code to use copy of given parameters list in `diff` method. Root cause (before fix) https://github.com/OpenAPITools/openapi-diff/blob/f595a84b9620d2ea65a9b0b71364810e4e3003d4/core/src/main/java/org/openapitools/openapidiff/core/compare/ParametersDiff.java#L66
- added few tests to cover this case

Issue affects `2.0.x` and `master` branches.
Ports
- to `2.0.x`: https://github.com/OpenAPITools/openapi-diff/pull/453
- to `master`: https://github.com/OpenAPITools/openapi-diff/pull/454
