### PR TITLE
Update maven-core to 3.8.2

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.6.0</version>
+      <version>3.8.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
There is a vulnerability to `maven-shared-utils` and it is fixed by updating maven-core to 3.8.2