### PR TITLE
Treat new PUT request properties as compatible again

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedSchema.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedSchema.java
@@ -1,6 +1,5 @@
 package org.openapitools.openapidiff.core.model;
 
-import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -157,9 +156,6 @@ public class ChangedSchema implements ComposedChanged {
   }
 
   private boolean compatibleForRequest() {
-    if (PathItem.HttpMethod.PUT.equals(context.getMethod()) && !increasedProperties.isEmpty()) {
-      return false;
-    }
     return (oldSchema != null || newSchema == null);
   }
 

--- a/core/src/test/java/org/openapitools/openapidiff/core/AddPropPutDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/AddPropPutDiffTest.java
@@ -1,9 +1,10 @@
 package org.openapitools.openapidiff.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiAreEquals;
-import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiBackwardIncompatible;
 
 import org.junit.jupiter.api.Test;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 
 public class AddPropPutDiffTest {
   private final String OPENAPI_DOC1 = "add-prop-put-1.yaml";
@@ -15,7 +16,9 @@ public class AddPropPutDiffTest {
   }
 
   @Test
-  public void testDiffDifferent() {
-    assertOpenApiBackwardIncompatible(OPENAPI_DOC1, OPENAPI_DOC2);
+  public void testFieldAdditionalInPutApiIsCompatible() {
+    ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_DOC2);
+    assertThat(changedOpenApi.isDifferent()).isTrue();
+    assertThat(changedOpenApi.isCompatible()).isTrue();
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/AddPropPutDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/AddPropPutDiffTest.java
@@ -17,6 +17,7 @@ public class AddPropPutDiffTest {
 
   @Test
   public void testFieldAdditionalInPutApiIsCompatible() {
+    // See https://github.com/OpenAPITools/openapi-diff/pull/537
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_DOC2);
     assertThat(changedOpenApi.isDifferent()).isTrue();
     assertThat(changedOpenApi.isCompatible()).isTrue();


### PR DESCRIPTION
Effectively reverts change for #136 (and PR #137) which appear invalid in intent, implementation, and test.
- Invalid in intent: #136 claims that adding a readOnly property to the request body of a PUT request is a breaking change because clients will begin to omit it and the server will interpret the omission as a directive to delete the property. This is incorrect because the server should expect, [per the OAS spec](https://spec.openapis.org/oas/v3.0.3#fixed-fields-19), that readOnly properties "SHOULD NOT be sent as part of the request". So it would be a bug for the server to delete any data associated with the readOnly property. Regardless, the API is left unbroken if the server simply ignores readOnly properties.
- Invalid in implementation: the code treats as incompatible any new PUT request property, not just readOnly properties.
- Invalid in test: no readOnly properties are tested.

In theory one could argue that some servers might enforce the "SHOULD NOT" language of the spec by returning validation errors where they didn't before, and this would constitute an API breakage. But that should be discussed in a different issue.

Fixes #537
Refs #136
Refs #137