### PR TITLE
Option to create html doc with all changes

### DIFF
--- a/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
+++ b/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
@@ -194,9 +194,9 @@ public class Main {
       }
       if (line.hasOption("html-detailed")) {
         HtmlRender htmlRender = new HtmlRender(true);
-        String output = htmlRender.render(result);
-        String outputFile = line.getOptionValue("html-detailed");
-        writeOutput(output, outputFile);
+        FileOutputStream outputStream = new FileOutputStream(line.getOptionValue("html-detailed"));
+        OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+        htmlRender.render(result, outputStreamWriter);
       }
       if (line.hasOption("markdown")) {
         MarkdownRender mdRender = new MarkdownRender();

--- a/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
+++ b/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
@@ -93,8 +93,15 @@ public class Main {
             .longOpt("html")
             .hasArg()
             .argName("file")
-            .desc("export diff as html in given file")
+            .desc("export diff as html in given file with incompatible changes")
             .build());
+    options.addOption(
+            Option.builder()
+                    .longOpt("html-detailed")
+                    .hasArg()
+                    .argName("file")
+                    .desc("export diff as html in given file with all changes")
+                    .build());
     options.addOption(
         Option.builder()
             .longOpt("text")
@@ -184,6 +191,12 @@ public class Main {
         FileOutputStream outputStream = new FileOutputStream(line.getOptionValue("html"));
         OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
         htmlRender.render(result, outputStreamWriter);
+      }
+      if (line.hasOption("html-detailed")) {
+        HtmlRender htmlRender = new HtmlRender(true);
+        String output = htmlRender.render(result);
+        String outputFile = line.getOptionValue("html-detailed");
+        writeOutput(output, outputFile);
       }
       if (line.hasOption("markdown")) {
         MarkdownRender mdRender = new MarkdownRender();

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOperation.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/ChangedOperation.java
@@ -63,6 +63,9 @@ public class ChangedOperation implements ComposedChanged {
   public DiffResult resultRequestBody() {
     return requestBody == null ? DiffResult.NO_CHANGES : requestBody.isChanged();
   }
+  public DiffResult resultSecurityRequirements() {
+    return securityRequirements == null ? DiffResult.NO_CHANGES : securityRequirements.isChanged();
+  }
 
   public Operation getOldOperation() {
     return this.oldOperation;


### PR DESCRIPTION
Created an option for the HtmlRenderer to show all changes, not just changes that are incompatible. Right now, only missing properties are displayed, so I added the option to show the changed and added properties. I have also shown changed security requirements. I have an attached a pictures to show a before and after of the changes.
![Before](https://github.com/OpenAPITools/openapi-diff/assets/77759605/b4882f0b-e154-4d40-aef3-4be4d0b23f57)
![After](https://github.com/OpenAPITools/openapi-diff/assets/77759605/26421204-19d6-492b-9431-3bdecbf2b36c)
