### PR TITLE
Fix renderer memory issues by writing to OutputStream

### DIFF
--- a/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
+++ b/cli/src/main/java/org/openapitools/openapidiff/cli/Main.java
@@ -2,9 +2,9 @@ package org.openapitools.openapidiff.cli;
 
 import ch.qos.logback.classic.Level;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
@@ -14,7 +14,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openapitools.openapidiff.core.OpenApiCompare;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
@@ -175,29 +174,33 @@ public class Main {
       ChangedOpenApi result = OpenApiCompare.fromLocations(oldPath, newPath, auths);
       ConsoleRender consoleRender = new ConsoleRender();
       if (!logLevel.equals("OFF")) {
-        System.out.println(consoleRender.render(result));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+        consoleRender.render(result, outputStreamWriter);
+        System.out.println(outputStream);
       }
       if (line.hasOption("html")) {
         HtmlRender htmlRender = new HtmlRender();
-        String output = htmlRender.render(result);
-        String outputFile = line.getOptionValue("html");
-        writeOutput(output, outputFile);
+        FileOutputStream outputStream = new FileOutputStream(line.getOptionValue("html"));
+        OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+        htmlRender.render(result, outputStreamWriter);
       }
       if (line.hasOption("markdown")) {
         MarkdownRender mdRender = new MarkdownRender();
-        String output = mdRender.render(result);
-        String outputFile = line.getOptionValue("markdown");
-        writeOutput(output, outputFile);
+        FileOutputStream outputStream = new FileOutputStream(line.getOptionValue("markdown"));
+        OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+        mdRender.render(result, outputStreamWriter);
       }
       if (line.hasOption("text")) {
-        String output = consoleRender.render(result);
-        String outputFile = line.getOptionValue("text");
-        writeOutput(output, outputFile);
+        FileOutputStream outputStream = new FileOutputStream(line.getOptionValue("text"));
+        OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+        consoleRender.render(result, outputStreamWriter);
       }
       if (line.hasOption("json")) {
         JsonRender jsonRender = new JsonRender();
-        String outputFile = line.getOptionValue("json");
-        jsonRender.renderToFile(result, outputFile);
+        FileOutputStream outputStream = new FileOutputStream(line.getOptionValue("json"));
+        OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+        jsonRender.render(result, outputStreamWriter);
       }
       if (line.hasOption("state")) {
         System.out.println(result.isChanged().getValue());
@@ -218,17 +221,6 @@ public class Main {
               + e.getMessage()
               + "\n"
               + ExceptionUtils.getStackTrace(e));
-      System.exit(2);
-    }
-  }
-
-  private static void writeOutput(String output, String outputFile) {
-    File file = new File(outputFile);
-    logger.debug("Output file: {}", file.getAbsolutePath());
-    try {
-      FileUtils.writeStringToFile(file, output, StandardCharsets.UTF_8);
-    } catch (IOException e) {
-      logger.error("Impossible to write output to file {}", outputFile, e);
       System.exit(2);
     }
   }

--- a/core/src/main/java/org/openapitools/openapidiff/core/exception/RendererException.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/exception/RendererException.java
@@ -1,0 +1,12 @@
+package org.openapitools.openapidiff.core.exception;
+
+public class RendererException extends RuntimeException {
+
+  public RendererException(Throwable cause) {
+    super(cause);
+  }
+
+  public RendererException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/org/openapitools/openapidiff/core/output/HtmlRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/HtmlRender.java
@@ -26,16 +26,20 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import j2html.rendering.FlatHtml;
 import j2html.tags.ContainerTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.HtmlTag;
 import j2html.tags.specialized.LiTag;
 import j2html.tags.specialized.OlTag;
 import j2html.tags.specialized.UlTag;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import org.openapitools.openapidiff.core.exception.RendererException;
 import org.openapitools.openapidiff.core.model.ChangedApiResponse;
 import org.openapitools.openapidiff.core.model.ChangedContent;
 import org.openapitools.openapidiff.core.model.ChangedMediaType;
@@ -71,7 +75,7 @@ public class HtmlRender implements Render {
     this.linkCss = linkCss;
   }
 
-  public String render(ChangedOpenApi diff) {
+  public void render(ChangedOpenApi diff, OutputStreamWriter outputStreamWriter) {
     this.diff = diff;
 
     List<Endpoint> newEndpoints = diff.getNewEndpoints();
@@ -86,10 +90,16 @@ public class HtmlRender implements Render {
     List<ChangedOperation> changedOperations = diff.getChangedOperations();
     OlTag ol_changed = ol_changed(changedOperations);
 
-    return renderHtml(ol_newEndpoint, ol_missingEndpoint, ol_deprecatedEndpoint, ol_changed);
+    renderHtml(
+        ol_newEndpoint, ol_missingEndpoint, ol_deprecatedEndpoint, ol_changed, outputStreamWriter);
   }
 
-  public String renderHtml(OlTag ol_new, OlTag ol_miss, OlTag ol_deprec, OlTag ol_changed) {
+  public void renderHtml(
+      OlTag ol_new,
+      OlTag ol_miss,
+      OlTag ol_deprec,
+      OlTag ol_changed,
+      OutputStreamWriter outputStreamWriter) {
     HtmlTag html =
         html()
             .attr("lang", "en")
@@ -110,7 +120,14 @@ public class HtmlRender implements Render {
                                 div().with(h2("What's Deprecated"), hr(), ol_deprec),
                                 div().with(h2("What's Changed"), hr(), ol_changed))));
 
-    return document().render() + html.render();
+    try {
+      FlatHtml<OutputStreamWriter> flatHtml = FlatHtml.into(outputStreamWriter);
+      document().render(flatHtml);
+      html.render(flatHtml);
+      outputStreamWriter.close();
+    } catch (IOException e) {
+      throw new RendererException("Problem rendering html document.", e);
+    }
   }
 
   private OlTag ol_newEndpoint(List<Endpoint> endpoints) {

--- a/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/JsonRender.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.io.OutputStreamWriter;
+import org.openapitools.openapidiff.core.exception.RendererException;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 
 public class JsonRender implements Render {
@@ -17,21 +18,14 @@ public class JsonRender implements Render {
   }
 
   @Override
-  public String render(ChangedOpenApi diff) {
+  public void render(ChangedOpenApi diff, OutputStreamWriter outputStreamWriter) {
     try {
-      return objectMapper.writeValueAsString(diff);
+      objectMapper.writeValue(outputStreamWriter, diff);
+      outputStreamWriter.close();
     } catch (JsonProcessingException e) {
-      throw new RuntimeException("Could not serialize diff as JSON", e);
-    }
-  }
-
-  public void renderToFile(ChangedOpenApi diff, String file) {
-    try {
-      objectMapper.writeValue(Paths.get(file).toFile(), diff);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException("Could not serialize diff as JSON", e);
+      throw new RendererException("Could not serialize diff as JSON", e);
     } catch (IOException e) {
-      throw new RuntimeException("Could not write to JSON file", e);
+      throw new RendererException(e);
     }
   }
 }

--- a/core/src/main/java/org/openapitools/openapidiff/core/output/Render.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/Render.java
@@ -1,8 +1,19 @@
 package org.openapitools.openapidiff.core.output;
 
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import org.openapitools.openapidiff.core.exception.RendererException;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 
 public interface Render {
 
-  String render(ChangedOpenApi diff);
+  void render(ChangedOpenApi diff, OutputStreamWriter outputStreamWriter);
+
+  default void safelyAppend(OutputStreamWriter outputStreamWriter, String csq) {
+    try {
+      outputStreamWriter.append(csq);
+    } catch (IOException ex) {
+      throw new RendererException(ex);
+    }
+  }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/AdditionalPropertiesTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/AdditionalPropertiesTest.java
@@ -2,6 +2,8 @@ package org.openapitools.openapidiff.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import org.junit.jupiter.api.Test;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.output.ConsoleRender;
@@ -9,8 +11,11 @@ import org.openapitools.openapidiff.core.output.ConsoleRender;
 class AdditionalPropertiesTest {
   @Test
   void booleanAdditionalPropertiesAreSupported() {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff = OpenApiCompare.fromLocations("issue-256_1.json", "issue-256_2.json");
     ConsoleRender render = new ConsoleRender();
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/ConsoleRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/ConsoleRenderTest.java
@@ -2,6 +2,8 @@ package org.openapitools.openapidiff.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import org.junit.jupiter.api.Test;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.output.ConsoleRender;
@@ -10,16 +12,22 @@ public class ConsoleRenderTest {
   @Test
   public void renderDoesNotFailWhenPropertyHasBeenRemoved() {
     ConsoleRender render = new ConsoleRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff =
         OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   @Test
   public void renderDoesNotFailWhenHTTPStatusCodeIsRange() {
     ConsoleRender render = new ConsoleRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff =
         OpenApiCompare.fromLocations("range_statuscode_1.yaml", "range_statuscode_2.yaml");
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/HtmlRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/HtmlRenderTest.java
@@ -2,6 +2,8 @@ package org.openapitools.openapidiff.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import org.junit.jupiter.api.Test;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.output.HtmlRender;
@@ -10,8 +12,11 @@ public class HtmlRenderTest {
   @Test
   public void renderDoesNotFailWhenPropertyHasBeenRemoved() {
     HtmlRender render = new HtmlRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff =
         OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/JsonRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/JsonRenderTest.java
@@ -2,6 +2,8 @@ package org.openapitools.openapidiff.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import org.junit.jupiter.api.Test;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.output.JsonRender;
@@ -10,16 +12,22 @@ public class JsonRenderTest {
   @Test
   public void renderDoesNotFailWhenPropertyHasBeenRemoved() {
     JsonRender render = new JsonRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff =
         OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   @Test
   public void renderDoesNotFailForJsr310Types() {
     JsonRender render = new JsonRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff =
         OpenApiCompare.fromLocations("jsr310_property_1.yaml", "jsr310_property_2.yaml");
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/MarkdownRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/MarkdownRenderTest.java
@@ -2,6 +2,8 @@ package org.openapitools.openapidiff.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import org.junit.jupiter.api.Test;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.output.MarkdownRender;
@@ -10,23 +12,32 @@ public class MarkdownRenderTest {
   @Test
   public void renderDoesNotFailWhenPropertyHasBeenRemoved() {
     MarkdownRender render = new MarkdownRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff =
         OpenApiCompare.fromLocations("missing_property_1.yaml", "missing_property_2.yaml");
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   @Test
   public void renderDoesNotCauseStackOverflowWithRecursiveDefinitions() {
     MarkdownRender render = new MarkdownRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff = OpenApiCompare.fromLocations("recursive_old.yaml", "recursive_new.yaml");
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   @Test
   public void renderDoesNotFailWhenHTTPStatusCodeIsRange() {
     MarkdownRender render = new MarkdownRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
     ChangedOpenApi diff =
         OpenApiCompare.fromLocations("range_statuscode_1.yaml", "range_statuscode_2.yaml");
-    assertThat(render.render(diff)).isNotBlank();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/OpenApiDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/OpenApiDiffTest.java
@@ -6,12 +6,10 @@ import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiAreEquals
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.core.models.ParseOptions;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.file.Path;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 import org.openapitools.openapidiff.core.model.ChangedOperation;
 import org.openapitools.openapidiff.core.model.DiffResult;
@@ -19,6 +17,7 @@ import org.openapitools.openapidiff.core.model.Endpoint;
 import org.openapitools.openapidiff.core.output.HtmlRender;
 import org.openapitools.openapidiff.core.output.JsonRender;
 import org.openapitools.openapidiff.core.output.MarkdownRender;
+import org.openapitools.openapidiff.core.output.Render;
 
 public class OpenApiDiffTest {
 
@@ -35,7 +34,7 @@ public class OpenApiDiffTest {
   }
 
   @Test
-  public void testNewApi(@TempDir Path tempDir) throws IOException {
+  public void testNewApi() {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_EMPTY_DOC, OPENAPI_DOC2);
     List<Endpoint> newEndpoints = changedOpenApi.getNewEndpoints();
     List<Endpoint> missingEndpoints = changedOpenApi.getMissingEndpoints();
@@ -44,18 +43,16 @@ public class OpenApiDiffTest {
     assertThat(missingEndpoints).isEmpty();
     assertThat(changedEndPoints).isEmpty();
 
-    String html =
-        new HtmlRender("Changelog", "http://deepoove.com/swagger-diff/stylesheets/demo.css")
-            .render(changedOpenApi);
-    final Path path = tempDir.resolve("testNewApi.html");
-    try (FileWriter fw = new FileWriter(path.toFile())) {
-      fw.write(html);
-    }
-    assertThat(path).isNotEmptyFile();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+    Render render =
+        new HtmlRender("Changelog", "http://deepoove.com/swagger-diff/stylesheets/demo.css");
+    render.render(changedOpenApi, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   @Test
-  public void testDeprecatedApi(@TempDir Path tempDir) throws IOException {
+  public void testDeprecatedApi() {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_EMPTY_DOC);
     List<Endpoint> newEndpoints = changedOpenApi.getNewEndpoints();
     List<Endpoint> missingEndpoints = changedOpenApi.getMissingEndpoints();
@@ -64,52 +61,46 @@ public class OpenApiDiffTest {
     assertThat(missingEndpoints).isNotEmpty();
     assertThat(changedEndPoints).isEmpty();
 
-    String html =
-        new HtmlRender("Changelog", "http://deepoove.com/swagger-diff/stylesheets/demo.css")
-            .render(changedOpenApi);
-    final Path path = tempDir.resolve("testDeprecatedApi.html");
-    try (FileWriter fw = new FileWriter(path.toFile())) {
-      fw.write(html);
-    }
-    assertThat(path).isNotEmptyFile();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+    Render render =
+        new HtmlRender("Changelog", "http://deepoove.com/swagger-diff/stylesheets/demo.css");
+    render.render(changedOpenApi, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   @Test
-  public void testDiff(@TempDir Path tempDir) throws IOException {
+  public void testDiff() {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_DOC2);
     List<ChangedOperation> changedEndPoints = changedOpenApi.getChangedOperations();
     assertThat(changedEndPoints).isNotEmpty();
 
-    String html =
-        new HtmlRender("Changelog", "http://deepoove.com/swagger-diff/stylesheets/demo.css")
-            .render(changedOpenApi);
-    final Path path = tempDir.resolve("testDiff.html");
-    try (FileWriter fw = new FileWriter(path.toFile())) {
-      fw.write(html);
-    }
-    assertThat(path).isNotEmptyFile();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+    Render render =
+        new HtmlRender("Changelog", "http://deepoove.com/swagger-diff/stylesheets/demo.css");
+    render.render(changedOpenApi, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   @Test
-  public void testDiffAndMarkdown(@TempDir Path tempDir) throws IOException {
+  public void testDiffAndMarkdown() {
     ChangedOpenApi diff = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_DOC2);
-    String render = new MarkdownRender().render(diff);
-    final Path path = tempDir.resolve("testDiff.md");
-    try (FileWriter fw = new FileWriter(path.toFile())) {
-      fw.write(render);
-    }
-    assertThat(path).isNotEmptyFile();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+    Render render = new MarkdownRender();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   @Test
-  public void testDiffAndJson(@TempDir Path tempDir) throws IOException {
+  public void testDiffAndJson() {
     ChangedOpenApi diff = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_DOC2);
-    String render = new JsonRender().render(diff);
-    final Path path = tempDir.resolve("testDiff.json");
-    try (FileWriter fw = new FileWriter(path.toFile())) {
-      fw.write(render);
-    }
-    assertThat(path).isNotEmptyFile();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+    Render render = new JsonRender();
+    render.render(diff, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 
   /** Testing that repetitive specs comparisons has to produce consistent result. */

--- a/core/src/test/java/org/openapitools/openapidiff/core/ResponseAddedContentSchemaTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/ResponseAddedContentSchemaTest.java
@@ -3,6 +3,8 @@ package org.openapitools.openapidiff.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.swagger.v3.oas.models.media.Content;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.openapitools.openapidiff.core.model.ChangedOpenApi;
@@ -10,6 +12,7 @@ import org.openapitools.openapidiff.core.model.ChangedResponse;
 import org.openapitools.openapidiff.core.output.ConsoleRender;
 import org.openapitools.openapidiff.core.output.HtmlRender;
 import org.openapitools.openapidiff.core.output.MarkdownRender;
+import org.openapitools.openapidiff.core.output.Render;
 
 public class ResponseAddedContentSchemaTest {
 
@@ -39,8 +42,22 @@ public class ResponseAddedContentSchemaTest {
   public void testDiffCanBeRendered() {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(OPENAPI_DOC1, OPENAPI_DOC2);
 
-    assertThat(new ConsoleRender().render(changedOpenApi)).isNotBlank();
-    assertThat(new HtmlRender().render(changedOpenApi)).isNotBlank();
-    assertThat(new MarkdownRender().render(changedOpenApi)).isNotBlank();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+    Render render = new ConsoleRender();
+    render.render(changedOpenApi, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
+
+    outputStream = new ByteArrayOutputStream();
+    outputStreamWriter = new OutputStreamWriter(outputStream);
+    render = new HtmlRender();
+    render.render(changedOpenApi, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
+
+    outputStream = new ByteArrayOutputStream();
+    outputStreamWriter = new OutputStreamWriter(outputStream);
+    render = new MarkdownRender();
+    render.render(changedOpenApi, outputStreamWriter);
+    assertThat(outputStream.toString()).isNotBlank();
   }
 }

--- a/maven/src/main/java/org/openapitools/openapidiff/maven/OpenApiDiffMojo.java
+++ b/maven/src/main/java/org/openapitools/openapidiff/maven/OpenApiDiffMojo.java
@@ -1,5 +1,7 @@
 package org.openapitools.openapidiff.maven;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -37,7 +39,10 @@ public class OpenApiDiffMojo extends AbstractMojo {
 
     try {
       final ChangedOpenApi diff = OpenApiCompare.fromLocations(oldSpec, newSpec);
-      getLog().info(new ConsoleRender().render(diff));
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+      new ConsoleRender().render(diff, outputStreamWriter);
+      getLog().info(outputStream.toString());
 
       if (failOnIncompatible && diff.isIncompatible()) {
         throw new BackwardIncompatibilityException("The API changes broke backward compatibility");


### PR DESCRIPTION
This fixes the issue with large diffs, which are not possible to render https://github.com/OpenAPITools/openapi-diff/issues/543

Closes #543