### PR TITLE
add test case for fixed NPE in rename of parameter (#488)

### DIFF
--- a/core/src/test/java/org/openapitools/openapidiff/core/ParameterDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/ParameterDiffTest.java
@@ -88,4 +88,10 @@ public class ParameterDiffTest {
     assertOpenApiChangedEndpoints(
         "issue-458-integer-limits_11.yaml", "issue-458-integer-limits_13.yaml");
   }
+
+  @Test
+  public void issue488RenameParameterAddAndRemoveParameterReturnFalse() {
+    assertOpenApiChangedEndpoints(
+        "issue-488-1.json", "issue-488-2.json");
+  }
 }

--- a/core/src/test/resources/issue-488-1.json
+++ b/core/src/test/resources/issue-488-1.json
@@ -1,0 +1,98 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test-API",
+    "description": "Testdescription",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v1/test": {
+      "get": {
+        "tags": [
+          "TestTag"
+        ],
+        "summary": "Retrieve a list Test objects",
+        "description": "Usage with testId parameter is recommended.",
+        "parameters": [
+          {
+            "name": "testId",
+            "in": "query",
+            "description": "rename of prop before",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "description": "Searches documents with creation date equal or younger specified timestamp",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "description": "Searches documents with creation date equal or older than specified timestamp",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TestDTO"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TestDTO": {
+        "type": "object",
+        "properties": {
+          "Id": {
+            "type": "string",
+            "nullable": true
+          },
+          "Timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "Test": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "apiKey",
+        "description": "Fill in your acquired bearer token here, must be like 'Bearer TOKEN_HERE'",
+        "name": "Authorization",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": [ ]
+    }
+  ]
+}

--- a/core/src/test/resources/issue-488-2.json
+++ b/core/src/test/resources/issue-488-2.json
@@ -1,0 +1,98 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test-API",
+    "description": "Testdescription",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v1/test": {
+      "get": {
+        "tags": [
+          "TestTag"
+        ],
+        "summary": "Retrieve a list Test objects",
+        "description": "Usage with testId parameter is recommended.",
+        "parameters": [
+          {
+            "name": "testIdWillBreak",
+            "in": "query",
+            "description": "rename of prop after",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "description": "Searches documents with creation date equal or younger specified timestamp",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "description": "Searches documents with creation date equal or older than specified timestamp",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TestDTO"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TestDTO": {
+        "type": "object",
+        "properties": {
+          "Id": {
+            "type": "string",
+            "nullable": true
+          },
+          "Timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "Test": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "apiKey",
+        "description": "Fill in your acquired bearer token here, must be like 'Bearer TOKEN_HERE'",
+        "name": "Authorization",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": [ ]
+    }
+  ]
+}


### PR DESCRIPTION
This issue has been fixed with commit 5b5b820a8555b8f503ca64fb9d4518ac179c1348 but no tests have been added to cover this.
**Result of the test before the commit 5b5b820a8555b8f503ca64fb9d4518ac179c1348 :**
![image](https://github.com/OpenAPITools/openapi-diff/assets/1172044/e98e63f8-4fe9-4d1f-8fd8-5e57ca4d0f45)

**Result of the test after commit 5b5b820a8555b8f503ca64fb9d4518ac179c1348** 
![image](https://github.com/OpenAPITools/openapi-diff/assets/1172044/e8db7110-585d-4ead-987c-044327fd1b9e)

Test for 
#488 
#516 
