### PR TITLE
Migrate from deprecated circleCi openJDK image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     working_directory: ~/openapi-diff
 
     docker:
-      - image: circleci/openjdk:8-jdk-node-browsers
+      - image: cimg/openjdk:8.0.442
 
     steps:
 


### PR DESCRIPTION
**circleci/xxx** images are deprecated: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034