### PR TITLE
Issue 422

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SchemaDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SchemaDiff.java
@@ -96,7 +96,7 @@ public class SchemaDiff {
             updatedVisitedRefs.add(composed.get$ref());
             composed = refPointer.resolveRef(components, composed, composed.get$ref());
             composed = resolveComposedSchema(components, composed, updatedVisitedRefs);
-            schema = addSchema(schema, composed);
+            addSchema(schema, composed);
           }
         }
         composedSchema.setAllOf(null);
@@ -340,8 +340,8 @@ public class SchemaDiff {
     left = refPointer.resolveRef(this.leftComponents, left, getSchemaRef(left));
     right = refPointer.resolveRef(this.rightComponents, right, getSchemaRef(right));
 
-    left = resolveComposedSchema(leftComponents, left, new HashSet<>());
-    right = resolveComposedSchema(rightComponents, right, new HashSet<>());
+    left = resolveComposedSchema(leftComponents, left, refSet.getLeftKeys());
+    right = resolveComposedSchema(rightComponents, right, refSet.getRightKeys());
 
     // If type of schemas are different, just set old & new schema, set changedType to true in
     // SchemaDiffResult and

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/RecursiveSchemaSet.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/deferred/RecursiveSchemaSet.java
@@ -7,12 +7,20 @@ public class RecursiveSchemaSet {
   HashSet<String> leftKeys = new HashSet<>();
   HashSet<String> rightKeys = new HashSet<>();
 
+  public HashSet<String> getLeftKeys() {
+    return leftKeys;
+  }
+
+  public HashSet<String> getRightKeys() {
+    return rightKeys;
+  }
+
   public boolean contains(CacheKey key) {
     return leftKeys.contains(key.getLeft()) || rightKeys.contains(key.getRight());
   }
 
   public void put(CacheKey key) {
     leftKeys.add(key.getLeft());
-    leftKeys.add(key.getRight());
+    rightKeys.add(key.getRight());
   }
 }

--- a/core/src/test/resources/recursive_model_1.yaml
+++ b/core/src/test/resources/recursive_model_1.yaml
@@ -25,6 +25,17 @@ components:
           type: string
         message2:
           type: string
+        recursiveDirect:
+          $ref: '#/components/schemas/B'
+        recursiveAllOf:
+          allOf:
+            - $ref: '#/components/schemas/B'
+        recursiveOneOf:
+          oneOf:
+            - $ref: '#/components/schemas/B'
+        recursiveAnyOf:
+          anyOf:
+            - $ref: '#/components/schemas/B'
         details:
           type: array
           items:


### PR DESCRIPTION
Have fixed the StackOverflow issue. `resolveComposedSchema` populates properties from 'allOf/anyOf' refs and if they contain recursive reference it creates a recursive data structure which fails further.

But apart from StackOverflow issue [the provided here openapi spec](https://github.com/OpenAPITools/openapi-diff/pull/475) fails with detected changes for the response. That's weird, haven't managed to figure out why yet.

```
==========================================================================
==                            API CHANGE LOG                            ==
==========================================================================
           Smart Manufacturing Operation Management Service API           
--------------------------------------------------------------------------
--                            What's Changed                            --
--------------------------------------------------------------------------
- GET    /smartmom-svc/api/views/workorders/{id}
  Return Type:
    - Changed 200 OK
      Media types:
        - Changed application/json
          Schema: Backward compatible
--------------------------------------------------------------------------
--                                Result                                --
--------------------------------------------------------------------------
                   API changes are backward compatible                    
--------------------------------------------------------------------------
```

I think it makes sense to merge this fix and handle the response diff issue later.

closes https://github.com/OpenAPITools/openapi-diff/issues/422