### PR TITLE
fix: No change if same minItems or maxItems

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/model/schema/ChangedMaxItems.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/schema/ChangedMaxItems.java
@@ -17,6 +17,9 @@ public class ChangedMaxItems implements Changed {
 
   @Override
   public DiffResult isChanged() {
+    if (oldValue == newValue) {
+      return DiffResult.NO_CHANGES;
+    }
     if (oldValue == null && newValue == null) {
       return DiffResult.NO_CHANGES;
     }

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/schema/ChangedMaxItems.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/schema/ChangedMaxItems.java
@@ -20,9 +20,6 @@ public class ChangedMaxItems implements Changed {
     if (oldValue == newValue) {
       return DiffResult.NO_CHANGES;
     }
-    if (oldValue == null && newValue == null) {
-      return DiffResult.NO_CHANGES;
-    }
     if (oldValue == null || newValue == null) {
       return DiffResult.COMPATIBLE;
     }

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/schema/ChangedMinItems.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/schema/ChangedMinItems.java
@@ -20,9 +20,6 @@ public class ChangedMinItems implements Changed {
     if (oldValue == newValue) {
       return DiffResult.NO_CHANGES;
     }
-    if (oldValue == null && newValue == null) {
-      return DiffResult.NO_CHANGES;
-    }
     if (oldValue == null || newValue == null) {
       return DiffResult.COMPATIBLE;
     }

--- a/core/src/main/java/org/openapitools/openapidiff/core/model/schema/ChangedMinItems.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/model/schema/ChangedMinItems.java
@@ -17,6 +17,9 @@ public class ChangedMinItems implements Changed {
 
   @Override
   public DiffResult isChanged() {
+    if (oldValue == newValue) {
+      return DiffResult.NO_CHANGES;
+    }
     if (oldValue == null && newValue == null) {
       return DiffResult.NO_CHANGES;
     }

--- a/core/src/test/java/org/openapitools/openapidiff/core/SchemaDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/SchemaDiffTest.java
@@ -180,6 +180,26 @@ public class SchemaDiffTest {
     assertThat(props.get("field4").getMaxItems().isIncompatible()).isTrue();
     assertThat(props.get("field4").getMaxItems().getOldValue()).isEqualTo(100);
     assertThat(props.get("field4").getMaxItems().getNewValue()).isEqualTo(90);
+
+    // Check removal of minItems
+    assertThat(props.get("field5").getMinItems().isCompatible()).isTrue();
+    assertThat(props.get("field5").getMinItems().getOldValue()).isEqualTo(1);
+    assertThat(props.get("field5").getMinItems().getNewValue()).isNull();
+
+    // Check removal of maxItems
+    assertThat(props.get("field5").getMaxItems().isCompatible()).isTrue();
+    assertThat(props.get("field5").getMaxItems().getOldValue()).isEqualTo(100);
+    assertThat(props.get("field5").getMaxItems().getNewValue()).isNull();
+
+    // Check addition of minItems
+    assertThat(props.get("field6").getMinItems().isCompatible()).isTrue();
+    assertThat(props.get("field6").getMinItems().getOldValue()).isNull();
+    assertThat(props.get("field6").getMinItems().getNewValue()).isEqualTo(1);
+
+    // Check addition of maxItems
+    assertThat(props.get("field6").getMaxItems().isCompatible()).isTrue();
+    assertThat(props.get("field6").getMaxItems().getOldValue()).isNull();
+    assertThat(props.get("field6").getMaxItems().getNewValue()).isEqualTo(100);
   }
 
   @Test // issue #482

--- a/core/src/test/java/org/openapitools/openapidiff/core/SchemaDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/SchemaDiffTest.java
@@ -144,7 +144,7 @@ public class SchemaDiffTest {
     assertThat(props.get("field4").getMultipleOf().getRight()).isNull();
   }
 
-  @Test // issues #480
+  @Test // issues #480 and #779
   public void changeMinMaxItemsHandling() {
     ChangedOpenApi changedOpenApi =
         OpenApiCompare.fromLocations(
@@ -157,6 +157,9 @@ public class SchemaDiffTest {
     assertThat(changedSchema).isNotNull();
     Map<String, ChangedSchema> props = changedSchema.getChangedProperties();
     assertThat(props).isNotEmpty();
+
+    // Check no changes in minItems and maxItems
+    assertThat(props.get("field0")).isNull();
 
     // Check increasing of minItems
     assertThat(props.get("field1").getMinItems().isIncompatible()).isTrue();

--- a/core/src/test/resources/schemaDiff/schema-min-max-items-diff-1.yaml
+++ b/core/src/test/resources/schemaDiff/schema-min-max-items-diff-1.yaml
@@ -16,6 +16,12 @@ components:
     TestDTO:
       type: object
       properties:
+        field0:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          maxItems: 10
         field1:
           type: array
           items:
@@ -33,7 +39,7 @@ components:
           items:
             type: string
           minItems: 1
-          maxItems: 90              
+          maxItems: 90
         field4:
           type: array
           items:

--- a/core/src/test/resources/schemaDiff/schema-min-max-items-diff-1.yaml
+++ b/core/src/test/resources/schemaDiff/schema-min-max-items-diff-1.yaml
@@ -46,3 +46,13 @@ components:
             type: string
           minItems: 1
           maxItems: 100
+        field5:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          maxItems: 100
+        field6:
+          type: array
+          items:
+            type: string

--- a/core/src/test/resources/schemaDiff/schema-min-max-items-diff-2.yaml
+++ b/core/src/test/resources/schemaDiff/schema-min-max-items-diff-2.yaml
@@ -16,6 +16,12 @@ components:
     TestDTO:
       type: object
       properties:
+        field0:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          maxItems: 10
         field1:
           type: array
           items:
@@ -27,13 +33,13 @@ components:
           items:
             type: string
           minItems: 10
-          maxItems: 100  
+          maxItems: 100
         field3:
           type: array
           items:
             type: string
           minItems: 1
-          maxItems: 100  
+          maxItems: 100
         field4:
           type: array
           items:

--- a/core/src/test/resources/schemaDiff/schema-min-max-items-diff-2.yaml
+++ b/core/src/test/resources/schemaDiff/schema-min-max-items-diff-2.yaml
@@ -46,3 +46,13 @@ components:
             type: string
           minItems: 1
           maxItems: 90
+        field5:
+          type: array
+          items:
+            type: string
+        field6:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          maxItems: 100


### PR DESCRIPTION
Closes #779

Handling equal minItems or maxItems

Fixes this missing detail from https://github.com/OpenAPITools/openapi-diff/pull/753

Note:
The original PR considered that adding `minItems` or `maxItems` is a compatible change. I'm not sure I agree, but I added tests just in case