### PR TITLE
Allow missing security schemes

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementDiff.java
@@ -35,11 +35,22 @@ public class SecurityRequirementDiff {
 
   private LinkedHashMap<String, List<String>> contains(
       SecurityRequirement right, String schemeRef) {
-    SecurityScheme leftSecurityScheme = leftComponents.getSecuritySchemes().get(schemeRef);
+    Map<String, SecurityScheme> leftSchemes =
+        leftComponents != null ? leftComponents.getSecuritySchemes() : null;
+    Map<String, SecurityScheme> rightSchemes =
+        rightComponents != null ? rightComponents.getSecuritySchemes() : null;
     LinkedHashMap<String, List<String>> found = new LinkedHashMap<>();
 
+    if (leftSchemes == null || rightSchemes == null) {
+      if (right.containsKey(schemeRef)) {
+        found.put(schemeRef, right.get(schemeRef));
+      }
+      return found;
+    }
+
+    SecurityScheme leftSecurityScheme = leftSchemes.get(schemeRef);
     for (Map.Entry<String, List<String>> entry : right.entrySet()) {
-      SecurityScheme rightSecurityScheme = rightComponents.getSecuritySchemes().get(entry.getKey());
+      SecurityScheme rightSecurityScheme = rightSchemes.get(entry.getKey());
       if (leftSecurityScheme.getType() == rightSecurityScheme.getType()) {
         switch (leftSecurityScheme.getType()) {
           case APIKEY:

--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SecurityRequirementsDiff.java
@@ -52,22 +52,20 @@ public class SecurityRequirementsDiff {
 
   private List<Pair<SecurityScheme.Type, SecurityScheme.In>> getListOfSecuritySchemes(
       Components components, SecurityRequirement securityRequirement) {
+    if (components == null) {
+      throw new IllegalArgumentException("Missing components definition.");
+    }
+    Map<String, SecurityScheme> securitySchemes = components.getSecuritySchemes();
+    if (securitySchemes == null) {
+      return new ArrayList<>();
+    }
     return securityRequirement.keySet().stream()
         .map(
             x -> {
-              if (components == null) {
-                throw new IllegalArgumentException("Missing securitySchemes component definition.");
-              }
-              Map<String, SecurityScheme> securitySchemes = components.getSecuritySchemes();
-              if (securitySchemes == null) {
-                throw new IllegalArgumentException("Missing securitySchemes component definition.");
-              }
-
               SecurityScheme result = securitySchemes.get(x);
               if (result == null) {
                 throw new IllegalArgumentException("Impossible to find security scheme: " + x);
               }
-
               return result;
             })
         .map(this::getPair)

--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SecuritySchemeDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SecuritySchemeDiff.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.openapitools.openapidiff.core.model.ChangedSecurityScheme;
 import org.openapitools.openapidiff.core.model.ChangedSecuritySchemeScopes;
@@ -36,8 +37,15 @@ public class SecuritySchemeDiff extends ReferenceDiffCache<SecurityScheme, Chang
       String rightSchemeRef,
       List<String> rightScopes,
       DiffContext context) {
-    SecurityScheme leftSecurityScheme = leftComponents.getSecuritySchemes().get(leftSchemeRef);
-    SecurityScheme rightSecurityScheme = rightComponents.getSecuritySchemes().get(rightSchemeRef);
+    Map<String, SecurityScheme> leftSchemes =
+        leftComponents != null ? leftComponents.getSecuritySchemes() : null;
+    Map<String, SecurityScheme> rightSchemes =
+        rightComponents != null ? rightComponents.getSecuritySchemes() : null;
+    if (leftSchemes == null || rightSchemes == null) {
+      return RealizedChanged.empty();
+    }
+    SecurityScheme leftSecurityScheme = leftSchemes.get(leftSchemeRef);
+    SecurityScheme rightSecurityScheme = rightSchemes.get(rightSchemeRef);
     DeferredChanged<ChangedSecurityScheme> changedSecuritySchemeOpt =
         cachedDiff(
             new HashSet<>(),

--- a/core/src/test/java/org/openapitools/openapidiff/core/SecurityDiffTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/SecurityDiffTest.java
@@ -2,6 +2,7 @@ package org.openapitools.openapidiff.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.openapitools.openapidiff.core.TestUtils.assertSpecUnchanged;
 
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.junit.jupiter.api.Test;
@@ -90,15 +91,13 @@ public class SecurityDiffTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> OpenApiCompare.fromLocations(OPENAPI_DOC3, OPENAPI_DOC3));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> OpenApiCompare.fromLocations(OPENAPI_DOC4, OPENAPI_DOC4));
   }
 
   @Test
   public void testMissingSecurityDefinition() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> OpenApiCompare.fromLocations(OPENAPI_DOC5, OPENAPI_DOC5));
+    // A missing securitySchemes map (DOC4) or an entirely empty components block (DOC5) is valid
+    // OpenAPI
+    assertSpecUnchanged(OPENAPI_DOC4, OPENAPI_DOC4);
+    assertSpecUnchanged(OPENAPI_DOC5, OPENAPI_DOC5);
   }
 }


### PR DESCRIPTION
Fixes #737

A missing `components.securitySchemes` is valid OpenAPI, and as such should be accepted for diffing, rather than throwing an exception as it's currently doing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow diffing OpenAPI documents that omit `components.securitySchemes`, treating them as valid and unchanged instead of throwing errors. Fixes #737.

- **Bug Fixes**
  - Added null-safe handling for missing `components.securitySchemes` in security diff logic; treat absence as a no-op.
  - Updated tests to assert unchanged for specs without security schemes; still throw when a security requirement references a non-existent scheme.

<sup>Written for commit 8729ac4166665ae369b7b964b92bbe52fbf5e12d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-diff/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

