### PR TITLE
Fix ClassCastException when allOf array changes to type array

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/SchemaDiff.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/SchemaDiff.java
@@ -240,6 +240,9 @@ public class SchemaDiff {
     if (fromSchema.getMinItems() != null) {
       schema.setMinItems(fromSchema.getMinItems());
     }
+    if (fromSchema.getItems() != null) {
+      schema.setItems(fromSchema.getItems());
+    }
     if (fromSchema.getMaxProperties() != null) {
       schema.setMaxProperties(fromSchema.getMaxProperties());
     }

--- a/core/src/main/java/org/openapitools/openapidiff/core/compare/schemadiffresult/ArraySchemaDiffResult.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/compare/schemadiffresult/ArraySchemaDiffResult.java
@@ -1,7 +1,6 @@
 package org.openapitools.openapidiff.core.compare.schemadiffresult;
 
 import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.openapidiff.core.compare.OpenApiDiff;
 import org.openapitools.openapidiff.core.model.ChangedSchema;
@@ -22,9 +21,6 @@ public class ArraySchemaDiffResult extends SchemaDiffResult {
       T left,
       T right,
       DiffContext context) {
-    ArraySchema leftArraySchema = (ArraySchema) left;
-    ArraySchema rightArraySchema = (ArraySchema) right;
-
     DeferredChanged<ChangedSchema> superSchemaDiff =
         super.diff(refSet, leftComponents, rightComponents, left, right, context)
             .flatMap(
@@ -34,8 +30,8 @@ public class ArraySchemaDiffResult extends SchemaDiffResult {
                           .getSchemaDiff()
                           .diff(
                               refSet,
-                              leftArraySchema.getItems(),
-                              rightArraySchema.getItems(),
+                              left.getItems(),
+                              right.getItems(),
                               context.copyWithRequired(true));
                   itemsDiff.ifPresent(changedSchema::setItems);
                   return itemsDiff;

--- a/core/src/test/java/org/openapitools/openapidiff/core/Issue887Test.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/Issue887Test.java
@@ -1,10 +1,9 @@
 package org.openapitools.openapidiff.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.openapitools.openapidiff.core.TestUtils.assertOpenApiAreEquals;
 
 import org.junit.jupiter.api.Test;
-import org.openapitools.openapidiff.core.model.ChangedOpenApi;
 
 public class Issue887Test {
 
@@ -24,8 +23,7 @@ public class Issue887Test {
   }
 
   @Test
-  public void testAllOfArrayToDirectArrayIsCompatible() {
-    ChangedOpenApi diff = OpenApiCompare.fromLocations(ALLOF_ARRAY, DIRECT_ARRAY);
-    assertThat(diff.isCompatible()).isTrue();
+  public void testAllOfArrayToDirectArrayAreEquals() {
+    assertOpenApiAreEquals(ALLOF_ARRAY, DIRECT_ARRAY);
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/Issue887Test.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/Issue887Test.java
@@ -1,0 +1,31 @@
+package org.openapitools.openapidiff.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+import org.openapitools.openapidiff.core.model.ChangedOpenApi;
+
+public class Issue887Test {
+
+  private final String ALLOF_ARRAY = "issue-887-1.yaml";
+  private final String DIRECT_ARRAY = "issue-887-2.yaml";
+
+  @Test
+  public void testAllOfArrayToDirectArrayDoesNotThrow() {
+    assertThatCode(() -> OpenApiCompare.fromLocations(ALLOF_ARRAY, DIRECT_ARRAY))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testDirectArrayToAllOfArrayDoesNotThrow() {
+    assertThatCode(() -> OpenApiCompare.fromLocations(DIRECT_ARRAY, ALLOF_ARRAY))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testAllOfArrayToDirectArrayIsCompatible() {
+    ChangedOpenApi diff = OpenApiCompare.fromLocations(ALLOF_ARRAY, DIRECT_ARRAY);
+    assertThat(diff.isCompatible()).isTrue();
+  }
+}

--- a/core/src/test/resources/issue-887-1.yaml
+++ b/core/src/test/resources/issue-887-1.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestResponse'
+
+components:
+  schemas:
+    TestResponse:
+      type: object
+      properties:
+        valuations:
+          allOf:
+            - $ref: '#/components/schemas/Valuations'
+
+    Valuations:
+      type: array
+      items:
+        type: object
+        properties:
+          value:
+            type: string

--- a/core/src/test/resources/issue-887-2.yaml
+++ b/core/src/test/resources/issue-887-2.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestResponse'
+
+components:
+  schemas:
+    TestResponse:
+      type: object
+      properties:
+        valuations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Valuation'
+
+    Valuation:
+      type: object
+      properties:
+        value:
+          type: string


### PR DESCRIPTION
Fixes #887

When a property changes from `allOf` wrapping an array schema to a direct `type: array`, the left side stays a `ComposedSchema` after resolution while the right side is an `ArraySchema`. Casting both to `ArraySchema` threw `ClassCastException`.

Changes:
- copy `items` when merging composed schemas in `addSchema`
- use `Schema#getItems()` in `ArraySchemaDiffResult` instead of casting
- add regression test from the issue repro

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when diffing array schemas that change from an `allOf`-wrapped array to a direct `type: array`. Prevents ClassCastException and ensures the specs compare equal.

- **Bug Fixes**
  - Copy `items` in `addSchema` when merging composed schemas.
  - Use `Schema#getItems()` in `ArraySchemaDiffResult` instead of casting.
  - Strengthen regression: assert no exception and that both specs are equal.

<sup>Written for commit 99b2f79c7bf273a898d7710293f50e37e71248c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-diff/pull/916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

