### PR TITLE
Render operation description changes in HtmlRender

### DIFF
--- a/core/src/main/java/org/openapitools/openapidiff/core/output/HtmlRender.java
+++ b/core/src/main/java/org/openapitools/openapidiff/core/output/HtmlRender.java
@@ -203,6 +203,10 @@ public class HtmlRender implements Render {
               .orElse("");
 
       UlTag ul_detail = ul().withClass("detail");
+      if (result(changedOperation.getDescription()).isDifferent()) {
+        ul_detail.with(
+            li().with(h3("Description")).with(ul_metadata(changedOperation.getDescription())));
+      }
       if (result(changedOperation.getOperationId()).isDifferent()) {
         ul_detail.with(
             li().with(h3("Operation ID")).with(ul_operation_id(changedOperation.getOperationId())));
@@ -575,5 +579,14 @@ public class HtmlRender implements Render {
                         + Optional.ofNullable(changedOperationId.getLeft()).orElse("")
                         + " to "
                         + Optional.ofNullable(changedOperationId.getRight()).orElse("")));
+  }
+
+  private UlTag ul_metadata(ChangedMetadata metadata) {
+    return ul().withClass("change")
+        .with(
+            li().with(del(Optional.ofNullable(metadata.getLeft()).orElse("")).withClass(COMMENT))
+                .withText(" change into ")
+                .with(
+                    span(Optional.ofNullable(metadata.getRight()).orElse("")).withClass(COMMENT)));
   }
 }

--- a/core/src/test/java/org/openapitools/openapidiff/core/output/HtmlRenderTest.java
+++ b/core/src/test/java/org/openapitools/openapidiff/core/output/HtmlRenderTest.java
@@ -43,4 +43,19 @@ public class HtmlRenderTest {
     render.render(diff, outputStreamWriter);
     assertThat(outputStream.toString()).isNotBlank();
   }
+
+  @Test
+  public void issue857_rendersOperationDescriptionChange() {
+    HtmlRender render = new HtmlRender();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+    ChangedOpenApi diff = OpenApiCompare.fromLocations("issue-857-1.yaml", "issue-857-2.yaml");
+    render.render(diff, outputStreamWriter);
+    String html = outputStream.toString();
+    assertThat(html).contains("Description");
+    assertThat(html).contains("change into");
+    assertThat(html).contains(">Sample description</del>");
+    assertThat(html).contains(">Sample description changed</span>");
+    assertThat(html).doesNotContain("<ul class=\"detail\"></ul>");
+  }
 }

--- a/core/src/test/resources/issue-857-1.yaml
+++ b/core/src/test/resources/issue-857-1.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /sample-api/{id}/actions/CAN:
+    post:
+      description: Sample description
+      operationId: cancel_1
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '201':
+          description: Cancel executed

--- a/core/src/test/resources/issue-857-2.yaml
+++ b/core/src/test/resources/issue-857-2.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /sample-api/{id}/actions/CAN:
+    post:
+      description: Sample description changed
+      operationId: cancel_1
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '201':
+          description: Cancel executed


### PR DESCRIPTION
Fixes #857

Operation description changes were detected by the model but HtmlRender left the detail list empty.

Changes:
- render a Description section when the operation description differs
- add a small regression test with fixtures from the issue scenario

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show operation description changes in the HTML report so diffs are visible. Previously, the model detected description changes but the detail section rendered empty.

- **Bug Fixes**
  - Render a Description section for operations when the description differs, showing old and new values.
  - Added a regression test with sample OpenAPI fixtures to cover this scenario (issue 857).

<sup>Written for commit b4329f0d4fd6e32607f3b4464e480156814d46c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-diff/pull/917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

